### PR TITLE
Fix: Remove Telegram-specific delivery from dossier skill

### DIFF
--- a/.changeset/dossier-remove-telegram.md
+++ b/.changeset/dossier-remove-telegram.md
@@ -3,3 +3,9 @@
 ---
 
 dossier: remove Telegram-specific delivery instruction (delivery is orchestrator's responsibility)
+
+<!--
+bumps:
+  skills:
+    dossier: patch
+-->

--- a/.changeset/dossier-remove-telegram.md
+++ b/.changeset/dossier-remove-telegram.md
@@ -1,0 +1,5 @@
+---
+"@eins78/agent-skills": patch
+---
+
+dossier: remove Telegram-specific delivery instruction (delivery is orchestrator's responsibility)

--- a/skills/dossier/README.md
+++ b/skills/dossier/README.md
@@ -36,7 +36,7 @@ dossier/
 ## Dependencies
 
 **Required:** WebSearch, WebFetch (built into Claude Code)
-**Optional:** Telegram MCP (for delivery), last30days skill (for social signal), commit-notation skill (for commit messages)
+**Optional:** last30days skill (for social signal), commit-notation skill (for commit messages)
 
 ## Testing
 
@@ -52,7 +52,6 @@ To verify the skill works:
 
 - No automated quality check for citation completeness
 - Source reference file covers 13 domains — will grow with usage
-- No integration test for Telegram delivery (depends on MCP availability)
 - Template comments (REQUIRED/OPTIONAL markers) need to be stripped from final output
 
 ## Future Improvements

--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -10,7 +10,7 @@ license: MIT
 metadata:
   author: eins78
   repo: https://github.com/eins78/agent-skills
-  version: "1.0.0-beta.1"
+  version: "1.0.0-beta.2"
 ---
 
 # Dossier
@@ -60,7 +60,6 @@ Write dossier using `${CLAUDE_SKILL_DIR}/templates/dossier.md`:
 ### 5. DELIVER
 
 - Commit dossier folder (`D:` intention per commit-notation)
-- Telegram: summary + file attachment (+ ballot if created)
 - **Do NOT end the session** — stay available for follow-ups, iterations, or additional dossiers
 
 ## Output Convention


### PR DESCRIPTION
## Summary

- Removes `Telegram: summary + file attachment (+ ballot if created)` from the `dossier` skill's DELIVER step
- Delivery transport is the orchestrator's responsibility — not the skill's
- Also cleans up matching references in `README.md` (dependencies list and known gaps)
- Bumps skill version `1.0.0-beta.1` → `1.0.0-beta.2`

## Motivation

The dossier skill's responsibility ends at: research → write the report → commit it. How the result is delivered (Telegram, Slack, CLI output, etc.) depends on the session context and should be handled by the calling orchestrator or delegate layer, not baked into the skill itself.

## Test plan

- [x] `pnpm test` passes (skills parse correctly)
- [x] SKILL.md DELIVER section contains no transport-specific instructions
- [x] README.md no longer references Telegram in dependencies or known gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)