### PR TITLE
typescript-strict-patterns: stable 1.0.0

### DIFF
--- a/.changeset/20260411-213819.md
+++ b/.changeset/20260411-213819.md
@@ -1,0 +1,10 @@
+---
+"@eins78/agent-skills": minor
+---
+
+Promote `typescript-strict-patterns` to stable 1.0.0 — graduates from 1.0.0-beta.1 pre-release
+
+<!--
+bumps:
+  skills:
+-->

--- a/skills/typescript-strict-patterns/SKILL.md
+++ b/skills/typescript-strict-patterns/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 metadata:
   author: eins78
   repo: https://github.com/eins78/agent-skills
-  version: 1.0.0-beta.1
+  version: 1.0.0
 compatibility: Designed for Claude Code and Cursor
 ---
 


### PR DESCRIPTION
## Summary

- Promotes `typescript-strict-patterns` from `1.0.0-beta.1` to stable `1.0.0`
- Adds `minor` changeset for `@eins78/agent-skills` package (stable graduation)
- Version set directly in SKILL.md — standard bump script cannot graduate a pre-release to its exact base version (`1.0.0-beta.1 + patch = 1.0.1`)

## Test plan

- [ ] CI `Validate skills parse` passes (`pnpm test`)
- [ ] CI `Validate skill frontmatter` passes (`pnpm run validate`)
- [ ] CI `Check for changeset` passes (changeset found; empty `skills:` block validates cleanly)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)