### PR TITLE
apple-mail, apple-notes: document timeout + retry pattern for osascript

### DIFF
--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -18,6 +18,30 @@ Read email via Mail.app AppleScript. **No sending or modifying emails.**
 - Automation permissions granted (System Settings → Privacy & Security → Automation → Terminal/Claude Code → Mail)
 - If first access attempt times out, ask user to check for macOS permission dialog
 
+## Reliability: always wrap osascript with timeout + retry
+
+Apple Mail's AppleScript bridge hangs intermittently — sometimes for minutes — even on simple queries. The AppleScript-internal `with timeout of N seconds` does NOT kill a wedged osascript process. **Always wrap calls with shell-level `timeout` and retry on failure.**
+
+Pattern:
+
+```bash
+# Run osascript with 15s shell timeout, retry up to 3 times with 2s backoff.
+mail_query() {
+  local script="$1" attempt
+  for attempt in 1 2 3; do
+    result=$(timeout 15 osascript -e "$script" 2>&1) && { echo "$result"; return 0; }
+    sleep 2
+  done
+  echo "ERROR: Mail query failed after 3 attempts" >&2
+  return 1
+}
+
+# Usage:
+mail_query 'tell application "Mail" to count (messages of inbox whose read status is false)'
+```
+
+Reasonable defaults: **15s timeout, 3 retries, 2s sleep**. Bump the timeout for `messages of every mailbox` (cross-account searches) to 60s. If all 3 retries fail, report the failure and move on — never block a briefing on Mail.
+
 ## Account & Machine Context
 
 See `docs/email-accounts.md` for which accounts are configured on which machines.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -18,6 +18,24 @@ Read notes via Notes.app AppleScript. **No creating, updating, or deleting notes
 - Automation permissions granted (System Settings → Privacy & Security → Automation → Terminal/Claude Code → Notes)
 - If first access attempt times out, ask user to check for macOS permission dialog
 
+## Reliability: always wrap osascript with timeout + retry
+
+Notes.app's AppleScript bridge hangs intermittently. AppleScript-internal `with timeout of N seconds` does NOT kill a wedged osascript process — wrap with shell-level `timeout` and retry.
+
+```bash
+notes_query() {
+  local script="$1" attempt
+  for attempt in 1 2 3; do
+    result=$(timeout 15 osascript -e "$script" 2>&1) && { echo "$result"; return 0; }
+    sleep 2
+  done
+  echo "ERROR: Notes query failed after 3 attempts" >&2
+  return 1
+}
+```
+
+Reasonable defaults: **15s timeout, 3 retries, 2s sleep**. Bump to 30s for full-text search across many notes. If all retries fail, report and move on.
+
 ## Scripts
 
 ### List folders


### PR DESCRIPTION
## Summary

Adds a "Reliability: timeout + retry" section to both apple-mail/SKILL.md and apple-notes/SKILL.md documenting a copy-pasteable bash wrapper for osascript calls.

## Why

Mail.app and Notes.app AppleScript bridges hang intermittently. AppleScripts internal "with timeout of N seconds" does NOT kill a wedged osascript process — only a shell-level timeout does. Morning briefing pipeline lost its email section twice in two days (2026-04-14, 2026-04-15) to a single hang where a retry would have recovered.

## What

```bash
mail_query() {
  local script="$1" attempt
  for attempt in 1 2 3; do
    result=$(timeout 15 osascript -e "$script" 2>&1) && { echo "$result"; return 0; }
    sleep 2
  done
  echo "ERROR: Mail query failed after 3 attempts" >&2
  return 1
}
```

Defaults: 15s timeout, 3 retries, 2s sleep. Bump for cross-account searches.

## Test plan

- [ ] Verify wrapper kills a wedged osascript (e.g. force a Mail.app hang)
- [ ] Verify recovery on 2nd or 3rd attempt when first call times out
- [ ] Document that `timeout` requires coreutils (or use a fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
