### PR TITLE
fix: unbound SKILL_BUMPS variable in bump-skill-versions.sh

### DIFF
--- a/.changeset/20260415-134350.md
+++ b/.changeset/20260415-134350.md
@@ -1,0 +1,5 @@
+---
+"@eins78/agent-skills": patch
+---
+
+Fix unbound variable error in `bump-skill-versions.sh` when no skill version bumps are present in changesets

--- a/.dev/scripts/bump-skill-versions.sh
+++ b/.dev/scripts/bump-skill-versions.sh
@@ -22,6 +22,7 @@ echo "Scanning changesets for skill version bumps..."
 # Collect skill bumps from all pending changesets
 # Format: SKILL_NAME:BUMP_TYPE (one per line)
 all_bumps=""
+declare -A SKILL_BUMPS=()
 
 for cs_file in "$CHANGESET_DIR"/*.md; do
   [ ! -f "$cs_file" ] && continue
@@ -65,7 +66,6 @@ for cs_file in "$CHANGESET_DIR"/*.md; do
 done
 
 # Deduplicate: if same skill appears multiple times, keep highest bump
-declare -A SKILL_BUMPS
 while IFS= read -r line; do
   [ -z "$line" ] && continue
   skill="${line%%:*}"


### PR DESCRIPTION
## Problem

The Release workflow crashed on every push to `main` after PR #34 merged (run 24439356079):

```
.dev/scripts/bump-skill-versions.sh: line 85: SKILL_BUMPS: unbound variable
```

## Root Cause

`bump-skill-versions.sh` uses `set -euo pipefail`. The associative array `SKILL_BUMPS` was declared at line 68 (mid-script, after the `for` loop). When no pending changesets contain a `<!--bumps:-->` block with skill entries, `all_bumps` stays empty, the `while` loop never runs — and in certain bash versions, querying `${#SKILL_BUMPS[@]}` at line 85 on a declared-but-empty associative array triggers "unbound variable" under `set -u`.

## Fix

Move `declare -A SKILL_BUMPS=()` to the top of the script (line 25), alongside `all_bumps=""`. The `=()` explicitly initializes an empty array — safe under `set -u` across bash 4.x/5.x.

**Two-line change:**
- `+ declare -A SKILL_BUMPS=()` after `all_bumps=""` (line 25)
- `- declare -A SKILL_BUMPS` removed from mid-script (former line 68)

## Verification

- `bash .dev/scripts/bump-skill-versions.sh` exits 0 with "No skill version bumps found" (zero-bump path)
- `shellcheck` reports no new warnings (pre-existing SC1091/SC2001 are unrelated)

## Changeset

Included a `patch` changeset — this is an infra fix to the release tooling, not a skill update, so no `<!--bumps:-->` block needed.
