### PR TITLE
ci: include version in release PR title (release: X.Y.Z)

### DIFF
--- a/.changeset/20260415-release-pr-title.md
+++ b/.changeset/20260415-release-pr-title.md
@@ -1,0 +1,5 @@
+---
+"@eins78/agent-skills": patch
+---
+
+Release pipeline: include version in commit message and PR title (e.g. `release: 2.3.0` instead of `chore: release`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,28 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Compute next release version
+        id: nextver
+        run: |
+          # Predict the next package version from pending changesets so the
+          # release PR title and commit message can include the actual version
+          # (e.g. "release: 2.3.0") instead of a generic "chore: release".
+          npx changeset status --output=/tmp/changeset-status.json \
+            || echo '{"releases":[]}' > /tmp/changeset-status.json
+          NEXT=$(jq -r '.releases[] | select(.name=="@eins78/agent-skills") | .newVersion' \
+            /tmp/changeset-status.json | head -n1)
+          NEXT="${NEXT:-pending}"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Next version: $NEXT"
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
           publish: bash .dev/scripts/create-release.sh
-          commit: "chore: release"
-          title: "chore: release"
+          commit: "release: ${{ steps.nextver.outputs.version }}"
+          title: "release: ${{ steps.nextver.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Include the next package version in the release PR title and merge commit message — `release: 2.3.0` instead of the generic `chore: release`.

## What changes

- New step `Compute next release version` runs `npx changeset status --output=...` and parses `releases[0].newVersion` via jq into a `version` step output.
- `changesets/action`'s `title` and `commit` inputs now use `release: ${{ steps.nextver.outputs.version }}`.
- Includes a patch changeset for the version bump.

## Safety note

The `${{ steps.nextver.outputs.version }}` value is computed from `npx changeset status` JSON output via jq — it is internally controlled, never sourced from `github.event.*` user input. No script-injection vector.

## Edge case: no pending changesets

If `npx changeset status` produces no releases (e.g. on the publish run after the version PR merges), the step writes `version=pending`. In that case, no release PR is created anyway, so the title is irrelevant.

## Test plan

- [ ] CI green on this PR
- [ ] After admin-merge, observe Release run updates PR #37's title from `chore: release` to `release: 2.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
