### PR TITLE
chrome-browser: expand and consolidate automation flags

### DIFF
--- a/.changeset/chrome-browser-expand-flags.md
+++ b/.changeset/chrome-browser-expand-flags.md
@@ -1,0 +1,11 @@
+---
+"@eins78/agent-skills": minor
+---
+
+`chrome-browser`: expand and consolidate Chrome automation flags — disable password checks, AI mode badge, tab organization, autofill, media routing, background networking, and other UI distractions. Flags organized by category with inline comments.
+
+<!--
+bumps:
+  skills:
+    chrome-browser: minor
+-->

--- a/docs/sessionlogs/2026-04-15-chrome-browser-expand-flags.md
+++ b/docs/sessionlogs/2026-04-15-chrome-browser-expand-flags.md
@@ -1,0 +1,46 @@
+# Chrome Browser: Expand and Consolidate Automation Flags
+
+**Date:** 2026-04-15
+**Source:** Claude Code
+
+## Summary
+
+Expanded Chrome automation flags from 7 to 18 in the `chrome-browser` skill. Added password check suppression, AI mode badge removal, background activity reduction, and keychain bypass.
+
+## Key Accomplishments
+
+- Researched Chrome feature flags by scanning the CfT v147 framework binary (`strings` on the Mach-O)
+- Identified `AiModeOmniboxEntryPoint` and `OmniboxAiModeEntryPointVariations` for AI badge suppression
+- Identified `CustomizeChromeSidePanel` for Customize button (intentionally kept enabled)
+- Tested all 18 flags on a throwaway instance (port 9333) before applying
+- Decoded the orange theme color: `browser.theme.user_color2: -32768` = `#FF8000` (ARGB), set manually via profile
+- Applied flags to live launchd agent and verified on running Chrome process
+- Created PR eins78/agent-skills#35
+
+## Changes Made
+
+- Modified: `skills/chrome-browser/scripts/launch-chrome-cdp.sh` — expanded `CHROME_FLAGS` array with categorized comments
+- Modified: `skills/chrome-browser/com.example.chrome-cdp.plist` — matching flags in template plist
+- Modified: `skills/chrome-browser/SKILL.md` — version 1.1.0 → 1.2.0, updated Key Decisions table
+
+## Decisions
+
+- **Don't disable CustomizeChromeSidePanel:** User wants the Customize Chrome button to set theme colors
+- **Orange theme is profile-level:** Stored as `browser.theme.user_color2` in Preferences JSON, set manually once, persists across restarts — not a command-line concern
+- **12 disabled features in single flag:** Comma-separated `--disable-features` keeps process args clean and is forward-compatible (Chrome ignores unknown names)
+
+## Next Steps
+
+- [ ] Merge PR eins78/agent-skills#35 (includes earlier CfT migration commits from `feature/chrome-cdp-app-bundle`)
+- [ ] After merge, bump plugin version in metadata files and release
+
+## Repository State
+
+- Committed: `ea0e54c` — chrome-browser: expand and consolidate automation flags
+- Branch: `feature/chrome-cdp-app-bundle`
+- PR: https://github.com/eins78/agent-skills/pull/35
+
+## Plan Reference
+
+- Planned: expand and consolidate Chrome automation flags in skill
+- Executed: all planned skill changes applied, tested, committed, pushed, PR created

--- a/skills/chrome-browser/SKILL.md
+++ b/skills/chrome-browser/SKILL.md
@@ -57,8 +57,10 @@ ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147      # specific milestone
 | Headed (not headless) | User can log into sites manually, cookies persist for automation |
 | launchd KeepAlive on crash only | Restart on crash, but intentional quit stays quit |
 | `--no-first-run --no-default-browser-check` | Zero-friction automated sessions |
-| `--disable-features=Translate --disable-breakpad` | No translation popups, no crash reports |
-| `--disable-infobars` | Suppresses CfT's "only for automated testing" notice bar |
+| `--disable-infobars` + UI suppression flags | Suppress infobars, search engine choice, hang monitor, popup blocking, form repost dialogs |
+| `--disable-features=Translate,...` | Disable translation, password check, autofill, media routing, AI mode, tab organization, optimization hints |
+| `--password-store=basic --use-mock-keychain` | Bypass macOS keychain — no unlock prompts during automation |
+| Background reduction flags | Disable background networking, phishing detection, component updates, sync, metrics upload |
 | User-scope MCP (`-s user`) | Available across all projects |
 
 ## Troubleshooting

--- a/skills/chrome-browser/com.example.chrome-cdp.plist
+++ b/skills/chrome-browser/com.example.chrome-cdp.plist
@@ -9,13 +9,30 @@
     <key>ProgramArguments</key>
     <array>
         <string>/Users/USERNAME/.local/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing</string>
+        <!-- Core CDP / Profile -->
         <string>--remote-debugging-port=9222</string>
         <string>--user-data-dir=/Users/USERNAME/.cache/chrome-cdp-profile</string>
+        <!-- First-run / Default Browser -->
         <string>--no-default-browser-check</string>
         <string>--no-first-run</string>
-        <string>--disable-features=Translate</string>
-        <string>--disable-breakpad</string>
+        <!-- UI Suppression -->
         <string>--disable-infobars</string>
+        <string>--disable-search-engine-choice-screen</string>
+        <string>--disable-popup-blocking</string>
+        <string>--disable-prompt-on-repost</string>
+        <string>--disable-hang-monitor</string>
+        <!-- Background Activity Reduction -->
+        <string>--disable-breakpad</string>
+        <string>--disable-background-networking</string>
+        <string>--disable-client-side-phishing-detection</string>
+        <string>--disable-component-update</string>
+        <string>--disable-sync</string>
+        <string>--metrics-recording-only</string>
+        <!-- Password / Keychain -->
+        <string>--password-store=basic</string>
+        <string>--use-mock-keychain</string>
+        <!-- Disabled Features -->
+        <string>--disable-features=Translate,TranslateUI,PasswordCheck,PasswordManagerOnboarding,AutofillServerCommunication,MediaRouter,DialMediaRouteProvider,OptimizationHints,GlobalMediaControls,TabOrganization,AiModeOmniboxEntryPoint,OmniboxAiModeEntryPointVariations</string>
     </array>
 
     <!-- Start Chrome with CDP on login -->

--- a/skills/chrome-browser/scripts/launch-chrome-cdp.sh
+++ b/skills/chrome-browser/scripts/launch-chrome-cdp.sh
@@ -13,13 +13,35 @@ CFT_BIN="$HOME/.local/Applications/Google Chrome for Testing.app/Contents/MacOS/
 CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
 CHROME_FLAGS=(
+  # Core CDP / Profile
   --remote-debugging-port="${PORT}"
   --user-data-dir="${USER_DATA_DIR}"
+
+  # First-run / Default Browser
   --no-default-browser-check
   --no-first-run
-  --disable-features=Translate
-  --disable-breakpad
+
+  # UI Suppression
   --disable-infobars
+  --disable-search-engine-choice-screen
+  --disable-popup-blocking
+  --disable-prompt-on-repost
+  --disable-hang-monitor
+
+  # Background Activity Reduction
+  --disable-breakpad
+  --disable-background-networking
+  --disable-client-side-phishing-detection
+  --disable-component-update
+  --disable-sync
+  --metrics-recording-only
+
+  # Password / Keychain
+  --password-store=basic
+  --use-mock-keychain
+
+  # Disabled Features
+  --disable-features=Translate,TranslateUI,PasswordCheck,PasswordManagerOnboarding,AutofillServerCommunication,MediaRouter,DialMediaRouteProvider,OptimizationHints,GlobalMediaControls,TabOrganization,AiModeOmniboxEntryPoint,OmniboxAiModeEntryPointVariations
 )
 
 if curl -s "${CDP_URL}/json/version" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Expand Chrome automation flags from 7 to 18, organized by category:
- **UI suppression:** infobars, search engine choice, popup blocking, form repost, hang monitor
- **Background reduction:** networking, phishing detection, component updates, sync, metrics
- **Password/keychain:** basic password store, mock keychain
- **Disabled features:** translate, password check, autofill, media routing, AI mode badge, tab organization, optimization hints

Supersedes #35 (rebased onto current main, adapted to changeset pipeline).

## Test plan

- [x] All 18 flags tested on CfT v147.0.7727.24 — Chrome starts, CDP responds, all flags visible in process
- [ ] Verify no password check dialogs on login pages
- [ ] Verify no AI mode badge in address bar
- [ ] Verify no translation bar on foreign-language pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)