### PR TITLE
dossier: add commercial bias flagging from @young.mete Threads post

### DIFF
--- a/.changeset/dossier-commercial-bias.md
+++ b/.changeset/dossier-commercial-bias.md
@@ -1,0 +1,16 @@
+---
+"@eins78/agent-skills": patch
+---
+
+dossier: add commercial bias flagging guidance from @young.mete Threads post
+
+Adds source quality heuristic: explicitly flag commercial incentives in dossier
+output rather than silently down-weighting biased sources. Updates
+`sources-by-domain.md` (new Commercial Bias Flagging subsection, expanded Lowest
+tier) and `SKILL.md` (new EVALUATE step bullet).
+
+<!--
+bumps:
+  skills:
+    dossier: patch
+-->

--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -10,7 +10,7 @@ license: MIT
 metadata:
   author: eins78
   repo: https://github.com/eins78/agent-skills
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # Dossier
@@ -46,6 +46,7 @@ Each agent returns structured findings with URLs for every claim. Check `/last30
 - Build attribute tables appropriate to the domain
 - Cross-reference across agents — multi-source citations get highest weight
 - Flag contradictions
+- **Flag commercial incentives:** when sources have financial motivation, call this out explicitly in the dossier (e.g. "most links are vendor/affiliate sites") rather than silently discarding them
 
 ### 4. SYNTHESIZE
 

--- a/skills/dossier/references/sources-by-domain.md
+++ b/skills/dossier/references/sources-by-domain.md
@@ -31,9 +31,17 @@ When synthesizing findings, weight by source quality:
 | **High** | Community with engagement signals (upvotes, stars, views) | Crowd-validated |
 | **Medium** | Expert blog posts, comparison articles | Informed but single-perspective |
 | **Lower** | News coverage, marketing materials | May have bias or lack depth |
-| **Lowest** | AI-generated content, SEO articles | Often superficial or recycled |
+| **Lowest** | AI-generated content, SEO/affiliate articles, marketing content | Often superficial, recycled, or financially motivated |
 
 Cross-source signals are strongest: an item praised on Reddit AND HN AND official docs is high-confidence.
+
+### Commercial Bias Flagging
+
+When sources have financial incentives (affiliate sites, vendor comparison pages, service-provider blogs), flag this **explicitly in the dossier** rather than silently down-weighting:
+
+> "Most sources found are [type] with a commercial incentive to [framing]. The underlying facts are verifiable against [primary source], but treat the framing with skepticism."
+
+Apply especially when researching: financial/tax products, SaaS comparisons, health supplements, or any domain where vendors profit from the recommendation. (Source: @young.mete on Threads, DXPjx_JDuMR)
 
 ## last30days Integration
 


### PR DESCRIPTION
## Summary

- Adds commercial bias flagging guidance to the `dossier` skill, sourced from a Threads post by @young.mete
- Explicitly surfaces when sources have financial incentives rather than silently down-weighting them

## Source

https://www.threads.com/@young.mete/post/DXPjx_JDuMR

## What changed

- **`skills/dossier/references/sources-by-domain.md`**: Expanded the "Lowest" tier in Source Quality Weighting to include affiliate/marketing content; added a new "Commercial Bias Flagging" subsection with example language for surfacing source incentives in dossier output
- **`skills/dossier/SKILL.md`**: Added "Flag commercial incentives" bullet to the EVALUATE step; bumped version `1.0.1` → `1.0.2`
- **`.changeset/dossier-commercial-bias.md`**: Patch changeset with `bumps:` block for automated version tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
