### PR TITLE
feat: add agent-workspace skill (alpha)

### DIFF
--- a/.changeset/new-agent-workspace-skill.md
+++ b/.changeset/new-agent-workspace-skill.md
@@ -1,0 +1,11 @@
+---
+"@eins78/agent-skills": minor
+---
+
+`agent-workspace` (new, alpha `0.1.0-alpha.1`): pattern + protocol for shared repos designed for human + AI collaboration. One skeleton — `CLAUDE.md`, `README.md`, `docs/stories/`, `docs/sessionlogs/`, `docs/rules/`, `.claude/skills/`, `.claude/agents/` — that serves workspaces regardless of whether they mostly aggregate code, mostly carry shared knowledge, or both. Includes an ORIENT → LOCATE → CONTRIBUTE agent protocol, an interview-driven bootstrapping protocol, a "where does this go" lookup table, and scaffolds for `CLAUDE.md` and `README.md`. Experimental while the pattern gets further validation across real use.
+
+<!--
+bumps:
+  skills:
+    agent-workspace: minor
+-->

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,16 @@
       }
     },
     {
+      "name": "agent-workspace",
+      "description": "Use when entering, bootstrapping, or working inside a shared repo organized as an agent-workspace — a pattern for human + AI collaboration with conventions for story tracking, session logs, skills, and CLAUDE.md routing.",
+      "version": "0.1.0-alpha.1",
+      "source": "./skills/agent-workspace",
+      "author": {
+        "name": "Max Albrecht",
+        "email": "1@178.is"
+      }
+    },
+    {
       "name": "ai-review",
       "description": "Get AI code review from a second model (Gemini/OpenAI) mid-session via CLI. Use when asked to review code, get a second opinion, check quality, or verify implementation — especially in unfamiliar s...",
       "version": "0.0.3",

--- a/skills/agent-workspace/README.md
+++ b/skills/agent-workspace/README.md
@@ -1,0 +1,43 @@
+# agent-workspace
+
+A skill and pattern for **shared git repositories designed for human + AI collaboration**. Gives workspaces a predictable skeleton so agents can land cold, orient, and contribute without breaking the grain of ongoing work.
+
+> **Status:** alpha (`0.1.0-alpha.1`). Extracted from several working shared-team workspaces and still being generalized. Feedback welcome.
+
+## What's an agent-workspace?
+
+A git repo with enough convention that both humans and AI agents can navigate it by reflex:
+
+- `CLAUDE.md` at the root — AI routing guide ("when X → go to Y").
+- `README.md` — human scannable overview.
+- `docs/stories/` — multi-session work items tracked as folders.
+- `docs/sessionlogs/` — dated per-topic notes from agent and meeting sessions.
+- `docs/rules/` — imported into `CLAUDE.md` for workspace-specific agent behavior.
+- `.claude/skills/` and `.claude/agents/` — workspace-local, incubating before promotion.
+
+Workspaces vary in what they hold — some aggregate code across repos, some carry shared knowledge (rules, templates, playbooks), most carry both. The same skeleton applies regardless. See `references/concept.md` for rationale and `references/bootstrapping.md` for how to set one up.
+
+## When to use
+
+- You're setting up a shared repo that several people (and agents) will work in over time.
+- You already have an ad-hoc shared repo and want to convert it to the pattern.
+- You landed in an existing agent-workspace and want to understand what conventions apply.
+
+## Contents
+
+- [`SKILL.md`](SKILL.md) — agent protocol: how to orient, locate, contribute.
+- [`references/concept.md`](references/concept.md) — full explanation: what, why, variation, access boundaries.
+- [`references/bootstrapping.md`](references/bootstrapping.md) — interview protocol for producing `CLAUDE.md` + `README.md` for a new workspace.
+- [`references/structure.md`](references/structure.md) — canonical directory layout and "where does this go" lookup table.
+- [`templates/CLAUDE.md`](templates/CLAUDE.md) — scaffold CLAUDE.md for a new workspace.
+- [`templates/README.md`](templates/README.md) — scaffold README.md for a new workspace.
+
+## Related patterns
+
+- **Stories & sessionlogs** — pairs well with a `story-tracking` skill (see your org's skills repo or build your own).
+- **Plot** — [eins78/plot](https://github.com/eins78/plot) for the git-native plan/implementation workflow inside a workspace.
+- **Skills marketplace** — workspace-local skills that graduate live in a shared skills repo (this one, or an org equivalent).
+
+## License
+
+MIT.

--- a/skills/agent-workspace/SKILL.md
+++ b/skills/agent-workspace/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: agent-workspace
+description: >-
+  Use when entering, bootstrapping, or working inside a shared repo organized
+  as an "agent-workspace" — a workspace designed for humans and AI agents to
+  collaborate, with conventions for story tracking, session logs, skills, and
+  CLAUDE.md routing. Triggers: agent workspace, bootstrap workspace, set up
+  CLAUDE.md, workspace audit, "where does this go in the workspace".
+compatibility: claude-code, cursor
+license: MIT
+metadata:
+  author: eins78
+  repo: https://github.com/eins78/agent-skills
+  version: 0.1.0-alpha.1
+---
+
+# Agent Workspace
+
+An **agent-workspace** is a git repo structured so humans and AI agents can work in it together without friction. It's a pattern, not a product — a handful of directory conventions and files that let an agent land cold, orient itself, and contribute without breaking the grain of ongoing work.
+
+Workspaces vary widely in what they hold — some aggregate code across repos, some carry shared knowledge (rules, templates, playbooks), most carry both. The same skeleton applies regardless.
+
+Full concept & rationale: `${CLAUDE_SKILL_DIR}/references/concept.md`.
+Bootstrapping a new workspace: `${CLAUDE_SKILL_DIR}/references/bootstrapping.md`.
+
+## When to invoke this skill
+
+- You landed in a repo with `docs/stories/`, `docs/sessionlogs/`, or `.claude/skills/` — orient before acting.
+- The user says "bootstrap a workspace," "set up CLAUDE.md for this," "audit this workspace," or "where should this file go."
+- Converting an existing ad-hoc shared repo into the pattern.
+
+## Workflow: ORIENT → LOCATE → CONTRIBUTE
+
+### 1. ORIENT
+
+Before doing anything, read in this order:
+
+1. `CLAUDE.md` at the repo root — your routing guide. If missing, this is not (yet) an agent-workspace; flag it.
+2. `README.md` — human overview; may carry context CLAUDE.md assumes.
+3. `docs/stories/` index (usually `README.md` or an "Active Stories" section) — what work is live.
+4. `docs/sessionlogs/` — last 2-3 entries; see what happened recently and what's unresolved.
+5. `.claude/skills/` and `.claude/agents/` — workspace-local conventions that override generic behavior.
+
+If the user named a story or slug, jump to `docs/stories/{slug}/STORY-*.md` and follow story-tracking conventions.
+
+### 2. LOCATE
+
+Before creating any file, check the canonical homes (see `references/structure.md`):
+
+| Kind of content | Home |
+|---|---|
+| Multi-session work tracking | `docs/stories/{slug}/STORY-{slug}.md` |
+| Per-session notes | `docs/sessionlogs/YYYY-MM-DD-topic-slug.md` |
+| Project rules for agents | `docs/rules/` (imported from `CLAUDE.md`) |
+| Reusable templates | `docs/templates/` |
+| Workspace-local skills | `.claude/skills/{name}/` (incubate here before promoting) |
+| Workspace-local agents | `.claude/agents/{name}.md` |
+| Customer/project specifics | Moved to the corresponding customer workspace — **not here** |
+
+**Access boundary rule (critical):** customer-specific content belongs in the customer workspace, never in a workspace shared by a team/role. A shared workspace must be safe to share with every member of that group; a customer workspace is shared with that customer. Mixing them is a leak.
+
+### 3. CONTRIBUTE
+
+Follow the conventions the workspace already demonstrates:
+
+- **Language:** structural elements (filenames, frontmatter keys, headings in templates) in English; content in whatever language the team writes.
+- **Story updates:** append session summaries, update status markers, never silently rewrite history.
+- **Commits:** small, focused, conventional-ish prefixes (`docs:`, `D:`, `feature:` — match the repo).
+- **Skill incubation:** new skills live in the workspace until battle-tested AND generally useful. Only then promote to a shared skills repo.
+- **Dual-tool compatibility:** anything in `.claude/` must also work when loaded by Cursor. Prefer plain Markdown + frontmatter over Claude-Code-specific tool syntax in skill bodies.
+
+## Bootstrapping a new workspace
+
+Run the interview protocol in `references/bootstrapping.md`. It produces:
+
+- `CLAUDE.md` — AI routing guide (architecture, glossary, "when X → go to Y")
+- `README.md` — human scannable overview
+- `docs/{stories,sessionlogs,rules,templates}/` — standard directories seeded
+- `.claude/{skills,agents}/` — empty scaffolds with `.gitkeep`
+
+Templates live in `${CLAUDE_SKILL_DIR}/templates/`.
+
+## Red flags
+
+Stop and surface these to the user rather than patching over:
+
+- No `CLAUDE.md` at root → don't silently create one; ask whether this workspace should adopt the pattern.
+- Customer-specific content in a workspace shared by a group → flag as access-boundary violation.
+- Skills scattered outside `.claude/skills/` → flag; don't "helpfully" reorganize without approval.
+- Conflict between workspace `CLAUDE.md` and this skill → **workspace wins**. This skill describes the pattern; individual workspaces refine it.

--- a/skills/agent-workspace/references/bootstrapping.md
+++ b/skills/agent-workspace/references/bootstrapping.md
@@ -1,0 +1,128 @@
+# Bootstrapping a New Agent-Workspace
+
+Interview-driven protocol for producing a first-pass `CLAUDE.md` + `README.md` + directory skeleton for a new (or newly-converted) agent-workspace.
+
+## Entry prompt (for a human to paste)
+
+```
+I want to set up this repo as an agent-workspace.
+
+Read the agent-workspace skill (references/concept.md and references/structure.md)
+and then interview me using the AskUserQuestion tool. Cover: what this workspace
+is for, what it mostly holds (code across repos, shared knowledge, or both),
+who the users are, what exists vs what's missing, and what "customer content"
+rule applies.
+
+Ask non-obvious questions. Don't ask anything you can get by reading the repo.
+Stop when you can draft CLAUDE.md and README.md confidently. Then draft them.
+```
+
+## Interview flow
+
+```
+1. PURPOSE      — What is this workspace for? Who uses it?
+     ↓
+2. SCOPE        — What belongs here? What explicitly does NOT?
+     ↓
+3. CONTENT      — What does this workspace mostly hold?
+                  (code across repos, shared knowledge, or both)
+                  Map the main content areas.
+     ↓
+4. GLOSSARY     — Every acronym, every in-group term, every confusing name
+     ↓
+5. GAPS         — What's already here? What's missing from the skeleton?
+     ↓
+6. DOCUMENT     — Write CLAUDE.md, README.md, create skeleton dirs
+```
+
+## Question strategy
+
+**Don't ask what you can read.** Skip these:
+
+- "What languages do you use?" → grep/read package files.
+- "How many repos?" → count them.
+- "What's in this directory?" → look.
+
+**Do ask what the repo can't tell you:**
+
+- "What breaks if this service goes down?"
+- "Why are these two concerns in separate repos?"
+- "What acronym does your team use that nobody outside the team knows?"
+- "Who's allowed to read this workspace? Who isn't?"
+- "What's the most confusing thing for a new joiner?"
+- "What content have you deliberately *kept out* of this workspace, and why?"
+
+**Follow up on vague answers:**
+
+| Vague | Probe |
+|---|---|
+| "It's a standard setup" | "What would surprise someone coming from a standard setup?" |
+| "We mostly use X" | "What are the exceptions, and what drove them?" |
+| "You probably got it" | "Let me state my current understanding — tell me what's wrong." |
+
+## Stop conditions
+
+You're ready to draft when you can answer:
+
+- [ ] Can I write a 3-sentence paragraph describing what this workspace is for?
+- [ ] Can I name 3-5 concrete scenarios and say which file/directory they map to?
+- [ ] Do I know every acronym or jargon term used, with definitions I could hand to a newcomer?
+- [ ] Do I know what's **NOT** supposed to be here and where it belongs instead?
+- [ ] Can I describe the main content areas — architectures, roles, artifact categories, whatever applies — without hand-waving?
+
+If any box is unchecked, ask more questions.
+
+## Deliverables checklist
+
+After the interview, produce:
+
+- [ ] `CLAUDE.md` — see `templates/CLAUDE.md` scaffold.
+- [ ] `README.md` — see `templates/README.md` scaffold.
+- [ ] `docs/stories/` with `README.md` index and a copy of the story template.
+- [ ] `docs/sessionlogs/` with a `.gitkeep` (first sessionlog will be this bootstrap session itself).
+- [ ] `docs/rules/` with `.gitkeep` (or a first rule extracted from the interview).
+- [ ] `docs/templates/STORY-template.md` from the story-tracking skill.
+- [ ] `.claude/skills/` and `.claude/agents/` with `.gitkeep`.
+- [ ] A **first story** documenting the bootstrapping itself — meta, but useful: future contributors see why the workspace exists and what decisions shaped it.
+- [ ] A **first sessionlog** (today's date) summarizing this bootstrap.
+
+## Drafting guidance
+
+### CLAUDE.md quality bar
+
+| Section | Good | Bad |
+|---|---|---|
+| Opening | "Shared Product Owner methodology (rules, templates, role personas) for POs across the team. Customer-specific content lives in per-customer workspaces and is out of scope here." | "This is the PO workspace." |
+| Glossary | "**PDR**: Product Data Repository — ingests weather files via FTP, stores in S3." | "**PDR**: Product Data Repository." |
+| Routing | "Fix UI bugs → `apps/frontend/src/components/`" | "UI code is in the frontend." |
+| NOT rules | "**NOT** for customer data. **NOT** for personal notes. See pointers below." | (missing) |
+
+### README.md quality bar
+
+- Scannable in under 2 minutes.
+- 3-5 components max in any diagram.
+- Tables for repo / directory structure, not prose.
+- Link to `CLAUDE.md` for agent routing.
+- Link to story index.
+
+## Common first-draft errors
+
+Check your draft against these before declaring done:
+
+| Error | Example | Fix |
+|---|---|---|
+| Passive voice obscuring ownership | "Files are served from S3" | "Nginx serves files from S3" |
+| Missing intermediaries | Forgot the cache between API and DB | Redraw with every hop explicit |
+| Circular definition | "The ingester ingests" | Explain inputs, outputs, format |
+| Overlooked acronym | Used "CAP" without defining | Grep for all-caps tokens, define each |
+| Generic rule ("follow best practices") | "Write good commit messages" | "Commits use `docs:`, `feature:`, `fix:` prefixes" |
+
+## After drafting
+
+1. Read CLAUDE.md and README.md back to the user — they often catch errors fastest when they hear their own domain described back to them.
+2. Commit the skeleton. Don't push yet — let the user review.
+3. Open the first story (the bootstrap story) so the workspace has live content from minute one.
+
+## Note on spec-vs-practice
+
+Don't over-invest in the spec before you have real workspaces using it. This pattern was extracted from several working shared workspaces — the abstractions earned their place by solving concrete problems. If you're tempted to generalize further, build another workspace first and see whether the generalization is necessary.

--- a/skills/agent-workspace/references/concept.md
+++ b/skills/agent-workspace/references/concept.md
@@ -1,0 +1,97 @@
+# Concept: Agent-Workspaces
+
+## What this is
+
+An **agent-workspace** is a git repository structured so humans and AI agents can collaborate inside it over long periods without friction. The structure is a handful of directory conventions and a couple of required files — not a framework, not a product.
+
+The goal is simple: a person or an agent who has never seen the repo before can land cold, read two or three files, and know:
+
+1. What this workspace is for.
+2. What's currently happening in it.
+3. Where anything they produce should go.
+
+That's it. Everything else is derivative.
+
+## Why the pattern exists
+
+Three converging realities:
+
+1. **Shared repos drift.** Without convention, every contributor invents their own folder structure; knowledge is buried; new joiners (human or agent) spend hours orienting.
+2. **Agents are bad at guessing conventions.** If a repo has no `CLAUDE.md`, an agent will guess — often wrong. Guesses become precedent. Precedent becomes debt.
+3. **Non-code work is real work.** Teams produce rules, templates, decisions, stakeholder maps, role descriptions — output that deserves the same care as code: version control, review, incremental refinement. It doesn't fit in a wiki.
+
+An agent-workspace is the minimum structure that solves all three without becoming bureaucratic.
+
+## Variation
+
+Workspaces differ in what they mostly hold:
+
+- Some aggregate code across multiple repos (often via submodules) so search, navigation, and system-level understanding have a single home.
+- Some carry shared knowledge — rules, templates, role descriptions, playbooks — that a team of humans and agents refine over time.
+- Most carry some of both, and the mix shifts as the workspace matures.
+
+The pattern doesn't care. The same skeleton serves all of them. If clear sub-patterns emerge with real use, this document may later distinguish them. Until then: one concept, many contents.
+
+## The access boundary rule
+
+The single most important rule, and the one that burns people most often:
+
+> **Customer-specific content belongs in the customer workspace. A workspace shared by a group must be safe to share with every member of that group.**
+
+Violations:
+
+- A shared workspace containing a `customers/acme/` directory with commercial data → anyone joining the workspace now sees that customer's contract terms.
+- Customer-specific templates mixed with generic ones → the "reusable template" is actually only usable for one customer.
+- Meeting notes referencing unrelated customers in a shared workspace.
+
+**Fix:** move customer content to per-customer workspace repos. Shared workspaces can reference them (read-only submodule, symlink, or just a documented pointer), but the access boundary is enforced at the repo level.
+
+This is *not* an organizational preference. It's a **security and trust boundary**. Get it wrong and a new hire, agent, or external reviewer sees something they shouldn't.
+
+## Tiers of workspace
+
+Context for where this pattern fits in a larger setup:
+
+| Tier | Example | Autonomy | Scope |
+|---|---|---|---|
+| **Personal** | your own developer workspace | Solo, full autonomy | You |
+| **Project / Customer** | a product-wide workspace, a customer-specific workspace | Shared | One customer or product |
+| **Function / Role** | a role-specific methodology workspace, a sales-enablement workspace, a cloud-ops workspace | Shared | One role/function across customers |
+
+An agent-workspace is most valuable at tiers 2 and 3. Personal workspaces benefit from the structure but don't need all of it.
+
+## What makes a workspace "agent-ready"
+
+Minimum bar:
+
+- [ ] `CLAUDE.md` at root, covering: what this is, glossary, routing, rules, NOT-to-do.
+- [ ] `README.md` at root, scannable in under 2 minutes.
+- [ ] `docs/stories/` with a template and at least one real story.
+- [ ] `docs/sessionlogs/` receiving entries.
+- [ ] English for structural names (frontmatter keys, directory names) so skills are portable.
+- [ ] A decision about customer content: excluded, symlinked, or submoduled — explicit, not accidental.
+
+Nice to have:
+
+- [ ] `docs/rules/` split out from `CLAUDE.md` when rules get long.
+- [ ] `docs/templates/` for recurring artifact types.
+- [ ] `.claude/skills/` for workspace-local skills incubating toward a shared repo.
+- [ ] `.claude/agents/` for dispatched specialist agents.
+- [ ] Dual Claude Code + Cursor compatibility tested.
+
+## Anti-patterns
+
+| Anti-pattern | Why it hurts |
+|---|---|
+| CLAUDE.md as a flat list of links | No routing, no glossary — agent can't orient |
+| Session logs in git commits only | Decisions lost in commit noise; hard to read sequentially |
+| Skills scattered in random directories | Agents can't discover them; incubation path unclear |
+| Customer content in a shared workspace | Access boundary violation (see above) |
+| Structural elements in non-English | Breaks portability of shared skills; frontmatter keys especially |
+| "SPEC" as the only source of truth | Spec drifts from reality; extract the pattern from working implementations, not the other way around |
+
+## What this skill is not
+
+- Not a setup script. It's a pattern + protocol. The scaffolding is manual-but-guided.
+- Not opinionated about your tools. Works with Claude Code, Cursor, any AI tool that respects `CLAUDE.md`-style rules files.
+- Not a replacement for project-specific conventions. This is a *floor*, not a ceiling. Your `CLAUDE.md` should still encode what's specific to your domain.

--- a/skills/agent-workspace/references/structure.md
+++ b/skills/agent-workspace/references/structure.md
@@ -1,0 +1,124 @@
+# Canonical Structure
+
+The agent-workspace skeleton. Not every workspace needs every directory — start with the minimum and grow.
+
+## Tree
+
+```
+workspace-root/
+├── CLAUDE.md                        # AI routing guide (required)
+├── README.md                        # Human overview (required)
+├── docs/
+│   ├── stories/                     # Multi-session work items
+│   │   ├── README.md                # Index of active stories
+│   │   └── {slug}/
+│   │       └── STORY-{slug}.md
+│   ├── sessionlogs/                 # Dated per-topic session notes
+│   │   └── YYYY-MM-DD-topic-slug.md
+│   ├── rules/                       # Imported into CLAUDE.md
+│   │   └── products/{name}.md
+│   ├── templates/                   # Reusable artifact templates
+│   │   └── STORY-template.md
+│   ├── plans/                       # (optional, Plot convention) actionable plans
+│   │   ├── active/
+│   │   └── delivered/
+│   └── changelogs/                  # (optional) YYYY-MM.md rollups
+├── .claude/
+│   ├── skills/                      # Workspace-local skills (incubating)
+│   │   └── {skill-name}/SKILL.md
+│   └── agents/                      # Workspace-local specialist agents
+│       └── {agent-name}.md
+├── apps/                            # optional: code submodules
+├── infra/                           # optional: infra submodules
+├── context/                         # optional: role / domain knowledge
+└── scripts/                         # Workspace-level automation
+```
+
+## "Where does this go?" lookup
+
+| Kind of content | Home |
+|---|---|
+| New multi-session work item | `docs/stories/{slug}/STORY-{slug}.md` |
+| Story analysis (narrative) | `docs/stories/{slug}/analysis-{topic}.md` |
+| Story implementation plan (actionable, Plot-style) | `docs/plans/active/{plan}.md`, cross-referenced from story |
+| Per-session notes | `docs/sessionlogs/YYYY-MM-DD-topic-slug.md` |
+| Meeting notes | `docs/sessionlogs/YYYY-MM-DD-meeting-topic.md` **or** `docs/stories/{slug}/meeting-{date}.md` |
+| Agent behavior rule that applies repo-wide | `docs/rules/{topic}.md`, import from `CLAUDE.md` |
+| Rule that applies only to one product/submodule | `docs/rules/products/{name}.md` |
+| Reusable template for an artifact | `docs/templates/{artifact}-template.md` |
+| Workspace-local skill (incubating) | `.claude/skills/{skill-name}/SKILL.md` |
+| Workspace-local specialist agent | `.claude/agents/{agent-name}.md` |
+| Customer-specific knowledge | **Not in this workspace.** Move to customer workspace. |
+| Secrets, credentials | **Never.** Use a secret manager. |
+
+## Frontmatter conventions
+
+### Story frontmatter
+
+```markdown
+---
+title: Human-readable title
+status: active | paused | done | cancelled
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+jira: OPTIONAL-TICKET-ID
+---
+```
+
+### Sessionlog frontmatter
+
+Usually none — the filename carries the date and topic. If you need one:
+
+```markdown
+---
+date: YYYY-MM-DD
+topic: short-slug
+participants: [name1, name2]
+---
+```
+
+### Skill frontmatter
+
+Follows Agent Skills convention — see existing skills in this repo for examples. Key fields: `name`, `description` (triggers!), `compatibility`, `metadata.version`.
+
+## Language conventions
+
+- **Structural elements in English:** filenames, frontmatter keys, directory names, template section headings.
+- **Content in the team's language:** German, French, whatever. Mixed is fine within a file.
+- Reason: skills and agents are often shared across workspaces and orgs. English structure keeps them portable. Content stays natural.
+
+## Naming conventions
+
+- **Stories:** `{slug}/` or `{TICKET-ID}-{slug}/` — e.g. `wcag-audit/`, `PROJ-1234-wcag-audit/`.
+- **Sessionlogs:** `YYYY-MM-DD-topic-slug.md` — one file per topic (not per session). Always today's date at creation.
+- **Templates:** `{artifact}-template.md` — `STORY-template.md`, `sessionlog-template.md`.
+- **Rules:** descriptive slug — `git-workflow.md`, `commit-messages.md`, `products/{name}.md`.
+
+## Workspace-local vs shared skills
+
+Skills incubate in `.claude/skills/` inside the workspace until:
+
+1. They're battle-tested (used in real work for weeks, refined across multiple sessions).
+2. They're generally useful outside this workspace.
+
+Then promote to a shared skills repo (org-level or personal). Until then, local stays local. Don't publish half-baked skills.
+
+## The "NOT in this workspace" list
+
+Make these explicit in `CLAUDE.md`:
+
+- What kind of code/content **does not** belong here.
+- Which other workspace owns that content.
+- A pointer to the owning workspace.
+
+Example:
+
+```markdown
+## What This Workspace Is NOT For
+
+- **Code** — lives in `~/CODE/{product}-workspace`
+- **Customer-specific content** — lives in `{customer}-workspace`
+- **Secrets** — use 1Password / vault
+```
+
+This is worth more than it looks. Explicit exclusions save agents (and humans) from guessing.

--- a/skills/agent-workspace/templates/CLAUDE.md
+++ b/skills/agent-workspace/templates/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+> Scaffold. Replace all `{{…}}` placeholders. Delete sections that don't apply.
+
+## Workspace Purpose
+
+{{One paragraph: what this workspace is, who uses it, why it exists as a separate repo. Name the access boundary if relevant.}}
+
+## What This Workspace Is For
+
+- {{Primary use case 1}}
+- {{Primary use case 2}}
+- {{Primary use case 3}}
+
+## What This Workspace Is NOT For
+
+- **Code** — lives in {{pointer}}
+- **Customer-specific content** — lives in {{customer-workspace pointer}}
+- **Secrets** — {{secret manager}}
+
+## Domain Glossary
+
+| Term | Definition |
+|---|---|
+| **{{ACRONYM}}** | {{Expansion}} — {{one-sentence definition}} |
+| **{{Term}}** | {{Definition}} |
+
+## Repository / Directory Guide
+
+| You need to understand… | Go to… |
+|---|---|
+| {{Scenario}} | `{{path}}` |
+| {{Scenario}} | `{{path}}` |
+
+## Rules
+
+{{Import from docs/rules/ or inline. Examples:}}
+
+- Stories live in `docs/stories/{slug}/STORY-{slug}.md` — see `docs/templates/STORY-template.md`.
+- Session logs live in `docs/sessionlogs/YYYY-MM-DD-topic-slug.md` — one file per topic, not per session.
+- Commit with `docs:`, `feature:`, `fix:` prefixes.
+- {{Workspace-specific rule}}.
+
+{{For longer rule sets, split into files and import:}}
+
+@./docs/rules/{{topic}}.md
+
+## Conventions
+
+- **Language:** English for structural elements (filenames, frontmatter, directory names). Content in {{team language}}.
+- **Tooling:** Claude Code + Cursor both supported. Skills in `.claude/skills/` must work in both.
+- **Branch prefixes:** {{idea/, feature/, bug/, docs/, infra/}}
+- **Skill incubation:** skills stay in `.claude/skills/` until battle-tested and generally useful.
+
+## Active Stories
+
+See `docs/stories/README.md` for the live index.
+
+## Related Workspaces
+
+- `{{other-workspace}}` at `{{pointer}}` — {{relationship}}
+- `{{another-workspace}}` at `{{pointer}}` — {{relationship}}

--- a/skills/agent-workspace/templates/README.md
+++ b/skills/agent-workspace/templates/README.md
@@ -1,0 +1,62 @@
+# {{Workspace Name}}
+
+{{One paragraph: what this is, who uses it, why it exists. Aim for scannable.}}
+
+## Getting Started
+
+```bash
+git clone {{--recurse-submodules if the workspace aggregates code repos}} {{repo-url}}
+cd {{workspace}}
+{{bootstrap command, if any}}
+```
+
+## What's In Here
+
+{{Simple ASCII diagram or bullet list — 5-7 top-level items max}}
+
+```
+workspace/
+├── CLAUDE.md          # AI routing guide
+├── docs/
+│   ├── stories/       # Work tracking
+│   ├── sessionlogs/   # Session notes
+│   ├── rules/         # Agent behavior rules
+│   └── templates/     # Reusable artifact templates
+└── .claude/
+    ├── skills/        # Workspace-local skills
+    └── agents/        # Workspace-local agents
+```
+
+## What This Workspace Holds
+
+{{Delete sections below that don't apply. Most workspaces use some combination.}}
+
+### Repositories
+
+| Repo | Description |
+|---|---|
+| {{name}} | {{one line}} |
+
+### Knowledge Areas
+
+| Area | Contents |
+|---|---|
+| `docs/rules/` | {{e.g. agent behavior rules, commit conventions}} |
+| `docs/templates/` | {{e.g. artifact templates, role personas}} |
+| `context/` | {{e.g. role knowledge, stakeholder maps}} |
+
+## Working in This Workspace
+
+⚠️ {{Any constraints: read-only submodules, approval gates, customer access restrictions, etc.}}
+
+- Story tracking → see `docs/stories/README.md`
+- Session logs → add yours to `docs/sessionlogs/`
+- AI routing guide → [CLAUDE.md](./CLAUDE.md)
+
+## Related Workspaces
+
+- `{{other-workspace}}` — {{what lives there instead}}
+
+## License / Access
+
+{{License if OSS, access policy if internal}}


### PR DESCRIPTION
## TL;DR

New alpha skill `agent-workspace` — a pattern for shared git repos designed for human + AI collaboration. Single skeleton (`CLAUDE.md`, `docs/stories/`, `docs/sessionlogs/`, `docs/rules/`, `.claude/skills/`, `.claude/agents/`) that serves workspaces regardless of whether they mostly aggregate code, mostly carry shared knowledge, or both. Experimental — will iterate as real workspaces adopt it.

## What's here

Under `skills/agent-workspace/`:

- `SKILL.md` — agent protocol (ORIENT → LOCATE → CONTRIBUTE) + red flags
- `README.md` — human-facing overview
- `references/concept.md` — what, why, variation, access-boundary rule, tiers, anti-patterns
- `references/structure.md` — canonical tree, "where does this go" lookup, frontmatter conventions
- `references/bootstrapping.md` — interview-driven protocol to produce CLAUDE.md + README.md for a new workspace
- `templates/CLAUDE.md`, `templates/README.md` — scaffolds

Plus: `.claude-plugin/marketplace.json` entry, changeset (`minor` plugin bump).

## Deliberate decisions

- **Alpha (`0.1.0-alpha.1`)**: pattern extracted from a few working shared workspaces; not yet validated across unrelated adopters. Expect revisions.
- **One concept, no sub-variants**: an earlier draft distinguished "code-first" vs "knowledge-first" flavors; dropped after review because real workspaces drift toward being both and the distinction didn't change reader behavior. If stable sub-patterns emerge with use, the doc will distinguish them then.
- **Abstract descriptions only**: pattern described without reference to specific originating workspaces, customers, or people.

## Review time

~10 minutes. ~400 lines across 7 files. `references/concept.md` is the densest; skip `templates/*` unless curious about scaffold shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
