### PR TITLE
chrome-browser: v1.3.0 — tool-selection rules, page gotchas, launcher on PATH

### DIFF
--- a/.changeset/chrome-browser-tooling-and-docs.md
+++ b/.changeset/chrome-browser-tooling-and-docs.md
@@ -1,0 +1,11 @@
+---
+"@eins78/agent-skills": minor
+---
+
+chrome-browser: v1.3.0 — surface tool-selection rules (`browser_tabs` not `page.close()`, sequential calls, local-CDP verification), page-handling gotchas (`innerText` for SPAs, batch crawling inside `browser_run_code`, no `require('fs')`, Cloudflare patience, rate-limit guidance), an expanded "running but hung" troubleshooting checklist, and a stable `~/.local/bin/launch-chrome-cdp` symlink installed by `install-cft.sh` so cold sessions don't have to guess paths. Repo-rename URLs (`eins78/agent-skills` → `eins78/skills`) and pre-existing shellcheck warnings fixed.
+
+<!--
+bumps:
+  skills:
+    chrome-browser: minor
+-->

--- a/.changeset/chrome-browser-tooling-and-docs.md
+++ b/.changeset/chrome-browser-tooling-and-docs.md
@@ -2,7 +2,7 @@
 "@eins78/agent-skills": minor
 ---
 
-chrome-browser: v1.3.0 — surface tool-selection rules (`browser_tabs` not `page.close()`, sequential calls, local-CDP verification), page-handling gotchas (`innerText` for SPAs, batch crawling inside `browser_run_code`, no `require('fs')`, Cloudflare patience, rate-limit guidance), an expanded "running but hung" troubleshooting checklist, and a stable `~/.local/bin/launch-chrome-cdp` symlink installed by `install-cft.sh` so cold sessions don't have to guess paths. Repo-rename URLs (`eins78/agent-skills` → `eins78/skills`) and pre-existing shellcheck warnings fixed.
+chrome-browser: v1.3.0 — surface tool-selection rules (`browser_tabs` not `page.close()`, sequential calls, local-CDP verification), page-handling gotchas (`innerText` for SPAs, batch crawling inside `browser_run_code`, no `require('fs')`, Cloudflare patience, rate-limit guidance), an expanded "running but hung" troubleshooting checklist, and a stable `~/.local/bin/launch-chrome-cdp` symlink installed by `install-cft.sh` so cold sessions don't have to guess paths. Two pre-existing shellcheck warnings (SC2115, SC2054) also fixed.
 
 <!--
 bumps:

--- a/skills/chrome-browser/INSTALL.md
+++ b/skills/chrome-browser/INSTALL.md
@@ -19,6 +19,8 @@ ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147
 
 CfT installs to `~/.local/Applications/Google Chrome for Testing.app`. It has its own bundle ID (`com.google.chrome.for.testing`) and a distinctive "TEST" badge icon — macOS treats it as a separate app in the Dock.
 
+The script also creates a stable launcher entry point at `~/.local/bin/launch-chrome-cdp` (symlink → `scripts/launch-chrome-cdp.sh`). If `~/.local/bin` is on your `$PATH`, future sessions can simply call `launch-chrome-cdp` without knowing the skill's installation path.
+
 ## 2. Create a launchd plist
 
 Use `com.example.chrome-cdp.plist` as a template. Customize:
@@ -55,6 +57,10 @@ launchctl list | grep chrome-cdp
 
 # CfT installed
 ls ~/.local/Applications/Google\ Chrome\ for\ Testing.app/
+
+# Launcher symlink on PATH
+which launch-chrome-cdp     # → ~/.local/bin/launch-chrome-cdp
+readlink "$(which launch-chrome-cdp)"  # points into the skill scripts/ directory
 
 # After restarting Claude Code, test Playwright MCP tools:
 # browser_navigate, browser_snapshot, browser_tabs should all work

--- a/skills/chrome-browser/README.md
+++ b/skills/chrome-browser/README.md
@@ -14,8 +14,6 @@ Reusable setup guide for a dedicated Chrome for Testing (CfT) instance with CDP 
 
 Developed for qubert-config ([sessionlog](https://github.com/eins78/qubert-config/blob/main/docs/sessionlogs/2026-02-25-browser-automation-playwright-cdp.md)), then replicated on lima (home-workspace). Both setups validated and working.
 
-Lives in `eins78/skills` (formerly `eins78/agent-skills`).
-
 ## Key Insight
 
 Chrome enforces a single-instance lock per user-data-dir. When the user's daily Chrome is running, CDP can't bind to the default profile. The solution is a **dedicated `~/.cache/chrome-cdp-profile`** with Chrome for Testing — which also has its own `CFBundleIdentifier` (`com.google.chrome.for.testing`), giving it a distinct icon in the Dock without any hacks.

--- a/skills/chrome-browser/README.md
+++ b/skills/chrome-browser/README.md
@@ -14,6 +14,8 @@ Reusable setup guide for a dedicated Chrome for Testing (CfT) instance with CDP 
 
 Developed for qubert-config ([sessionlog](https://github.com/eins78/qubert-config/blob/main/docs/sessionlogs/2026-02-25-browser-automation-playwright-cdp.md)), then replicated on lima (home-workspace). Both setups validated and working.
 
+Lives in `eins78/skills` (formerly `eins78/agent-skills`).
+
 ## Key Insight
 
 Chrome enforces a single-instance lock per user-data-dir. When the user's daily Chrome is running, CDP can't bind to the default profile. The solution is a **dedicated `~/.cache/chrome-cdp-profile`** with Chrome for Testing — which also has its own `CFBundleIdentifier` (`com.google.chrome.for.testing`), giving it a distinct icon in the Dock without any hacks.
@@ -38,6 +40,7 @@ chrome-browser/
 | qubert | 2026-02-25 | Working (launchd, multi-session tested) |
 | lima | 2026-03-07 | Working (launchd, Playwright MCP verified) |
 | lima | 2026-03-30 | v1.1.0: Chrome for Testing + ergonomic flags |
+| mac-zrh | 2026-05-03 | v1.3.0: tool-selection + page gotchas docs, `~/.local/bin/launch-chrome-cdp` symlink, expanded troubleshooting |
 
 ## Dependencies
 

--- a/skills/chrome-browser/SKILL.md
+++ b/skills/chrome-browser/SKILL.md
@@ -4,7 +4,7 @@ description: Use when setting up a dedicated Chrome browser for Playwright MCP w
 license: MIT
 metadata:
   author: eins78
-  repo: https://github.com/eins78/skills
+  repo: https://github.com/eins78/agent-skills
   version: "1.3.0"
 ---
 
@@ -125,7 +125,7 @@ See [INSTALL.md](INSTALL.md) for the full setup checklist, including the launch 
 
 If you encounter a setup step that fails, a Chrome/Playwright behavior change, or missing guidance in this skill, don't just work around it — fix the skill:
 
-1. **Create a PR** from a fresh worktree of `https://github.com/eins78/skills` on a new branch, fixing the issue directly
-2. **Or file an issue** on `https://github.com/eins78/skills` with: what failed, the actual behavior, and the suggested fix
+1. **Create a PR** from a fresh worktree of `https://github.com/eins78/agent-skills` on a new branch, fixing the issue directly
+2. **Or file an issue** on `https://github.com/eins78/agent-skills` with: what failed, the actual behavior, and the suggested fix
 
 Never silently work around a skill gap. The fix benefits all future sessions.

--- a/skills/chrome-browser/SKILL.md
+++ b/skills/chrome-browser/SKILL.md
@@ -4,8 +4,8 @@ description: Use when setting up a dedicated Chrome browser for Playwright MCP w
 license: MIT
 metadata:
   author: eins78
-  repo: https://github.com/eins78/agent-skills
-  version: "1.2.0"
+  repo: https://github.com/eins78/skills
+  version: "1.3.0"
 ---
 
 # Dedicated Chrome Browser
@@ -39,13 +39,44 @@ curl -s http://127.0.0.1:9222/json/version
 # Configure Playwright MCP (user-scope, one-time)
 claude mcp add -s user playwright -- npx @playwright/mcp --cdp-endpoint http://127.0.0.1:9222
 
-# Manual launch (if not using launchd)
-${CLAUDE_SKILL_DIR}/scripts/launch-chrome-cdp.sh
+# Manual launch — prefer the PATH symlink (created by install-cft.sh)
+launch-chrome-cdp                                    # ~/.local/bin/launch-chrome-cdp
 
-# Install / update Chrome for Testing
+# Install / update Chrome for Testing (also (re)creates the launcher symlink)
 ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh          # latest stable
 ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147      # specific milestone
 ```
+
+### Finding the scripts when `${CLAUDE_SKILL_DIR}` isn't set
+
+Cold sessions or one-shot bash calls may not have `${CLAUDE_SKILL_DIR}`. After `install-cft.sh` has run once, the canonical entry point is on `$PATH`:
+
+```bash
+launch-chrome-cdp     # symlink in ~/.local/bin → skills/chrome-browser/scripts/launch-chrome-cdp.sh
+```
+
+If that's missing, locate the skill directory directly. **Do NOT guess** paths like `~/.cache/launch-chrome-cdp.sh`, and **do NOT fall back** to launching `/Applications/Google Chrome.app` manually — you'd bypass Chrome for Testing and the curated flag set:
+
+```bash
+SKILL_DIR="$(dirname "$(find ~/.claude/skills ~/.claude/plugins ~/CODE \
+  -path '*/chrome-browser/scripts/launch-chrome-cdp.sh' 2>/dev/null | head -1)")"
+"${SKILL_DIR}/launch-chrome-cdp.sh"
+```
+
+## Using the browser via Playwright MCP
+
+- **Close tabs:** use the `browser_tabs` tool (close action). Playwright `page.close()` does NOT work over CDP — it fails silently.
+- **One tab at a time:** close each tab when done. If 10+ tabs accumulate, close all and start fresh.
+- **Sequential, not parallel:** browser tool calls in parallel race the same Chrome instance. Wait for the previous call to settle before issuing the next.
+- **Verify you're talking to the local CDP:** `curl -s http://127.0.0.1:9222/json/version | jq .webSocketDebuggerUrl` should return a `ws://127.0.0.1:9222/...` URL. If it points at another host, the MCP config has been pointed at a remote CDP — fix it before doing anything else.
+
+## Working with pages
+
+- **React / SPA text extraction:** use `innerText`, not `textContent`. React's virtual DOM may leave text nodes empty while `innerText` reflects rendered visual output.
+- **Batch crawling:** `page.goto()` works inside `browser_run_code` for multi-page work without an MCP round-trip per page. Add 1–2 s between navigations to avoid rate limiting.
+- **No filesystem inside `browser_run_code`:** `require('fs')` is unavailable in the Playwright MCP sandbox. Return data as the function's return value, or POST it to a local HTTP server.
+- **Cloudflare:** if a site shows a challenge / waiting page, just wait — the browser MCP usually handles it. Real blocks are rare. Don't retry in a tight loop, and don't open a second tab to the same site.
+- **Rate limits:** sites like Galaxus / Digitec block after ~100+ rapid requests. Crawl slowly (1–2 s/page); expect a ~5 min cool-off after a block.
 
 ## Key Decisions
 
@@ -65,10 +96,26 @@ ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147      # specific milestone
 
 ## Troubleshooting
 
-- **Cloudflare challenges:** If a site shows a Cloudflare challenge/waiting page, just wait — the browser MCP can usually handle it. We are very rarely actually blocked.
-- **CDP not responding:** Run `${CLAUDE_SKILL_DIR}/scripts/launch-chrome-cdp.sh` to start or check status.
-- **Profile conflicts:** If Chrome complains about profile lock, check for zombie Chrome processes: `ps aux | grep chrome-cdp-profile`
-- **CfT update:** Run `${CLAUDE_SKILL_DIR}/scripts/install-cft.sh` to download and install the latest stable version.
+**CDP unreachable** (`curl -s http://127.0.0.1:9222/json/version` is empty or errors):
+
+1. `launchctl list | grep chrome-cdp` — is the launchd agent loaded?
+2. `pgrep -f chrome-cdp-profile` — is a Chrome process actually running?
+3. **Process exists but CDP is dead** (the "running but hung" case): `pkill -f chrome-cdp-profile`, wait 2 s, then `launch-chrome-cdp` (or `${CLAUDE_SKILL_DIR}/scripts/launch-chrome-cdp.sh`).
+4. **Launchd shows non-zero exit** in `launchctl list`: check the stdout/stderr paths defined in your plist.
+
+**CDP reaches the wrong machine:**
+
+```bash
+curl -s http://127.0.0.1:9222/json/version | jq .webSocketDebuggerUrl
+```
+
+The URL must start with `ws://127.0.0.1:9222/`. If it points at a different host, the Playwright MCP `--cdp-endpoint` is wrong — re-run the `claude mcp add` line in Quick Reference.
+
+**Profile lock errors:** zombie Chrome holding `~/.cache/chrome-cdp-profile`. `pkill -f chrome-cdp-profile`, wait 2 s, relaunch.
+
+**Cloudflare challenges:** wait, don't retry. Real blocks are very rare; they need a fresh IP, not another browser restart.
+
+**CfT update:** run `${CLAUDE_SKILL_DIR}/scripts/install-cft.sh` to download/install the latest stable version (it also refreshes the `launch-chrome-cdp` symlink).
 
 ## Setup
 
@@ -78,7 +125,7 @@ See [INSTALL.md](INSTALL.md) for the full setup checklist, including the launch 
 
 If you encounter a setup step that fails, a Chrome/Playwright behavior change, or missing guidance in this skill, don't just work around it — fix the skill:
 
-1. **Create a PR** from a fresh worktree of `https://github.com/eins78/agent-skills` on a new branch, fixing the issue directly
-2. **Or file an issue** on `https://github.com/eins78/agent-skills` with: what failed, the actual behavior, and the suggested fix
+1. **Create a PR** from a fresh worktree of `https://github.com/eins78/skills` on a new branch, fixing the issue directly
+2. **Or file an issue** on `https://github.com/eins78/skills` with: what failed, the actual behavior, and the suggested fix
 
 Never silently work around a skill gap. The fix benefits all future sessions.

--- a/skills/chrome-browser/scripts/install-cft.sh
+++ b/skills/chrome-browser/scripts/install-cft.sh
@@ -12,8 +12,13 @@ set -euo pipefail
 #   install-cft.sh 147.0.7727.24  Install exact version
 
 INSTALL_DIR="$HOME/.local/Applications"
+BIN_DIR="$HOME/.local/bin"
 APP_NAME="Google Chrome for Testing.app"
 VERSION="${1:-stable}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER_SRC="${SCRIPT_DIR}/launch-chrome-cdp.sh"
+LAUNCHER_DEST="${BIN_DIR}/launch-chrome-cdp"
 
 if ! command -v npx &>/dev/null; then
   echo "Error: npx not found. Install Node.js first." >&2
@@ -41,7 +46,7 @@ CfT_VERSION="$("${APP_PATH}/Contents/MacOS/Google Chrome for Testing" --version 
 mkdir -p "${INSTALL_DIR}"
 if [[ -d "${INSTALL_DIR}/${APP_NAME}" ]]; then
   echo "Replacing existing CfT installation..."
-  rm -rf "${INSTALL_DIR}/${APP_NAME}"
+  rm -rf "${INSTALL_DIR:?}/${APP_NAME}"
 fi
 cp -R "${APP_PATH}" "${INSTALL_DIR}/"
 
@@ -54,4 +59,18 @@ echo "  ${INSTALL_DIR}/${APP_NAME}"
 echo ""
 echo "Binary: ${INSTALL_DIR}/${APP_NAME}/Contents/MacOS/Google Chrome for Testing"
 echo ""
-echo "Next: update your launchd plist and reload, or run launch-chrome-cdp.sh"
+
+# Create / refresh the launcher symlink so cold sessions can find it on PATH.
+if [[ -x "${LAUNCHER_SRC}" ]]; then
+  mkdir -p "${BIN_DIR}"
+  ln -sf "${LAUNCHER_SRC}" "${LAUNCHER_DEST}"
+  echo "Launcher symlink: ${LAUNCHER_DEST} -> ${LAUNCHER_SRC}"
+  if ! echo ":${PATH}:" | grep -q ":${BIN_DIR}:"; then
+    echo "  Note: ${BIN_DIR} is not on \$PATH. Add it to your shell rc to use 'launch-chrome-cdp' directly."
+  fi
+else
+  echo "Warning: launcher script not found at ${LAUNCHER_SRC} — symlink not created." >&2
+fi
+
+echo ""
+echo "Next: update your launchd plist and reload, or run 'launch-chrome-cdp' (or ${LAUNCHER_SRC})"

--- a/skills/chrome-browser/scripts/launch-chrome-cdp.sh
+++ b/skills/chrome-browser/scripts/launch-chrome-cdp.sh
@@ -12,6 +12,7 @@ USER_DATA_DIR="$HOME/.cache/chrome-cdp-profile"
 CFT_BIN="$HOME/.local/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
 CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
+# shellcheck disable=SC2054  # commas inside --disable-features=... value are intentional Chrome syntax
 CHROME_FLAGS=(
   # Core CDP / Profile
   --remote-debugging-port="${PORT}"


### PR DESCRIPTION
## Summary

Promote lessons from past Claude Code sessions into the `chrome-browser` skill so cold agents stop tripping on the same gotchas. Bumps to v1.3.0.

**SKILL.md additions**
- **Using the browser via Playwright MCP** — `browser_tabs` (not Playwright `page.close()`), one-tab-at-a-time, sequential calls only, verify local CDP via `webSocketDebuggerUrl`
- **Working with pages** — React/SPA `innerText` over `textContent`, `page.goto()` inside `browser_run_code` for batch crawling, no `require('fs')` in the sandbox, Cloudflare patience, rate-limit guidance (Galaxus/Digitec ~100+ requests → 5 min cool-off)
- **Expanded Troubleshooting** — covers the running-but-hung case (`pgrep -f chrome-cdp-profile` + `pkill` recovery) and the wrong-host CDP case
- **Path discovery section** — inline `find` snippet for cold sessions where `${CLAUDE_SKILL_DIR}` isn't set

**install-cft.sh — installs a stable launcher entry point**
- Creates `~/.local/bin/launch-chrome-cdp` symlink pointing at the script in the skill, so future sessions can call `launch-chrome-cdp` directly from `$PATH` instead of guessing paths and silently falling back to `/Applications/Google Chrome.app` (which bypasses CfT and the curated flag set — observed in a 2026-03-29 session).
- Warns if `~/.local/bin` is not on `$PATH`.

**Misc**
- Fixed two pre-existing shellcheck warnings (SC2115 in `install-cft.sh`, SC2054 in `launch-chrome-cdp.sh` — Chrome's `--disable-features=A,B,C` syntax legitimately needs commas).
- Added a changeset (minor bump).

## Origins of these rules

| Rule | Source incident |
|------|-----------------|
| Use `browser_tabs`, not `page.close()` | 2026-01-18 — agent tried Playwright `page.close()`, failed silently |
| Verify local CDP `webSocketDebuggerUrl` | 2026-02-22 — agent connected to CDP on a different machine by accident |
| Running-but-hung recovery | 2026-04-12 — CDP listening but unresponsive, no documented recovery |
| `~/.local/bin/launch-chrome-cdp` symlink | 2026-03-29 — agent invented `~/.cache/launch-chrome-cdp.sh`, then fell back to plain Chrome |
| Page gotchas (innerText, fs, batch, rate limits) | Lived only in a personal CLAUDE.md until now |

## Test plan

- [ ] Re-run `install-cft.sh` and confirm `~/.local/bin/launch-chrome-cdp` is created and is executable
- [ ] `which launch-chrome-cdp` resolves; the launcher starts CDP on :9222
- [ ] `shellcheck skills/chrome-browser/scripts/*.sh` — clean
- [ ] Markdown renders correctly in the GitHub UI (no broken code fences from the multi-line `find` snippet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
