### PR TITLE
docs(chrome-browser): warn about conflict with claude-plugins-official/playwright

### DIFF
--- a/.changeset/chrome-browser-plugin-conflict-note.md
+++ b/.changeset/chrome-browser-plugin-conflict-note.md
@@ -1,0 +1,13 @@
+---
+"@eins78/agent-skills": patch
+---
+
+chrome-browser: document conflict with the official `claude-plugins-official/playwright` plugin
+
+The official `playwright` plugin from Anthropic's marketplace registers `npx @playwright/mcp@latest` without `--cdp-endpoint`, which causes Playwright to spawn its own bundled Chromium instead of attaching to the CfT instance set up by this skill — defeating the persistent-session purpose entirely. Added a callout in INSTALL.md step 3 with two resolution paths (disable the plugin via `~/.claude/settings.json`, or patch the plugin's bundled `.mcp.json`) plus a verification command.
+
+<!--
+bumps:
+  skills:
+    chrome-browser: patch
+-->

--- a/skills/chrome-browser/INSTALL.md
+++ b/skills/chrome-browser/INSTALL.md
@@ -46,6 +46,38 @@ claude mcp add -s user playwright -- npx @playwright/mcp --cdp-endpoint http://1
 
 Restart Claude Code to pick up the new MCP server.
 
+> [!IMPORTANT]
+> **Conflict with the official `claude-plugins-official/playwright` plugin**
+>
+> If you have the official `playwright` plugin enabled (from Anthropic's marketplace), it registers `npx @playwright/mcp@latest` **without `--cdp-endpoint`**. That makes Playwright spawn its own bundled Chromium for every tool call, ignoring your CfT instance entirely — you'll see two Chromes open and your CfT login session won't be used.
+>
+> Pick one of these to resolve:
+>
+> 1. **Disable the plugin** (cleanest). In `~/.claude/settings.json`, set the plugin entry to `false`:
+>    ```jsonc
+>    {
+>      "enabledPlugins": {
+>        "playwright@claude-plugins-official": false
+>      }
+>    }
+>    ```
+>    Then restart Claude Code. The user-scope MCP from step 3 above remains active and uses CfT.
+>
+> 2. **Patch the plugin's bundled `.mcp.json`** (quick, but reverted on plugin re-sync). Edit
+>    `~/.claude/plugins/cache/claude-plugins-official/playwright/<ver>/.mcp.json` (and the matching file under
+>    `~/.claude/plugins/marketplaces/...`) to add the flag:
+>    ```json
+>    {
+>      "playwright": {
+>        "command": "npx",
+>        "args": ["@playwright/mcp@latest", "--cdp-endpoint", "http://127.0.0.1:9222"]
+>      }
+>    }
+>    ```
+>    Restart Claude Code. Note: a future plugin update may revert this file.
+>
+> Verify: only one Chrome window opens after a Playwright tool call, and `curl -s http://127.0.0.1:9222/json | jq '.[].url'` shows the URL you just navigated to.
+
 ## 4. Verify
 
 ```bash


### PR DESCRIPTION
## Summary

The `chrome-browser` skill's `INSTALL.md` step 3 tells the user to register `playwright` as a user-scope MCP with `--cdp-endpoint http://127.0.0.1:9222`. That works **only if the official `claude-plugins-official/playwright` plugin is not enabled**. If it is enabled, the plugin's `.mcp.json` registers the same `playwright` MCP name without `--cdp-endpoint`, and Playwright happily spawns its own bundled Chromium for every tool call — defeating the entire purpose of CfT (persistent login session, stable identity, dedicated profile).

This PR adds a callout to step 3 documenting the conflict and giving two resolution paths.

## How I hit this

Debugging an Azure Portal automation flow tonight: CfT launched cleanly with the "TEST" badge icon, but every `browser_navigate` call opened a *different* Chromium with no Microsoft login session, while CfT just sat there with `chrome://newtab/`. Took ~30 minutes to figure out the official plugin had pre-empted my user-scope MCP registration with a flagless variant.

After patching the plugin's `.mcp.json` and reloading, things work as documented in this skill.

## What's in the PR

- `skills/chrome-browser/INSTALL.md` — adds an `> [!IMPORTANT]` callout under step 3 with:
  1. **Disable the plugin** via `~/.claude/settings.json` (cleanest, survives plugin updates)
  2. **Patch the plugin's bundled `.mcp.json`** (quicker, but may revert on plugin re-sync)
  3. A one-line verification command using the CDP HTTP API + `jq` to prove which Chrome the MCP is actually attached to
- `.changeset/chrome-browser-plugin-conflict-note.md` — patch-level changeset

## Test plan

- [x] Read `INSTALL.md` rendered output — callout block displays correctly
- [x] Verified the two fix paths both resolve the conflict (option 2 was used in the actual debugging session, option 1 is the recommended one)

## Notes

A more robust longer-term fix would be to recommend a different MCP name in step 3 (e.g. `playwright-cdp`) so it can coexist with the official plugin without collision, and update the rest of the skill to refer to that name. That's a larger change with implications for users who already followed the original instructions, so I'm just adding the warning here for now.
