### PR TITLE
chrome-browser: v1.4.0 — tool-selection hardening, recovery helpers, hardcoded launchd label

### DIFF
--- a/.changeset/chrome-browser-tool-selection-hardening.md
+++ b/.changeset/chrome-browser-tool-selection-hardening.md
@@ -1,0 +1,22 @@
+---
+"@eins78/agent-skills": minor
+---
+
+chrome-browser: harden tool selection and cold-start behaviour, and ship recovery/diagnostic helpers as official scripts.
+
+- Name the lookalike browser MCPs (`mcp__chrome-devtools__*`, `mcp__claude-in-chrome__*`) explicitly as forbidden so cold agents don't silently switch to them when Playwright errors transiently.
+- Add an "On activation" preflight (CDP alive, Playwright MCP loaded) since the audit showed all real failures cluster in the first ~30–60 s after skill load.
+- Forbid raw `curl`/CDP-WebSocket browser driving; clarify `browser_tabs` lists tabs (no action arg) as well as closing them.
+- Document one-time session loss after Chrome for Testing version bumps.
+- Hardcode the launchd label as `is.ars.chrome-cdp` (renamed plist `com.example.chrome-cdp.plist` → `is.ars.chrome-cdp.plist`) so troubleshooting commands work without machine-specific lookups. **Upgraders from v1.3 must unload and remove the old plist first** — see INSTALL.md §2.
+- Ship three new helper scripts on PATH (symlinked by `install-cft.sh`):
+  - `chrome-cdp-health` — liveness + endpoint check (exit 0/1/2).
+  - `chrome-cdp-restart` — kickstart launchd-managed Chrome when Playwright keeps erroring but CDP is alive.
+  - `chrome-cdp-tabs` — read-only tab listing; sanctioned alternative to ad-hoc `curl :9222/json` for out-of-band inspection. Action helpers (goto/click/eval) intentionally NOT shipped — those would compete with Playwright MCP and re-create the tool-selection problem.
+- Add `install-cft.sh --symlinks-only` to refresh helper symlinks without re-downloading CfT (and `-h`/`--help`). Lets users on existing CfT installs adopt the new helpers without the heavy npx download.
+
+<!--
+bumps:
+  skills:
+    chrome-browser: minor
+-->

--- a/docs/sessionlogs/2026-05-18-chrome-browser-hardening-helpers.md
+++ b/docs/sessionlogs/2026-05-18-chrome-browser-hardening-helpers.md
@@ -1,0 +1,52 @@
+# chrome-browser v1.4.0 — tool-selection hardening, recovery helpers, upgrade path
+
+**Date:** 2026-05-18
+**Source:** Claude Code
+**Session:** Reconstructed from 1 compaction
+
+## Summary
+
+Hardened the `chrome-browser` skill against recurring failure modes observed across many sessions: agents silently switching to lookalike MCPs (`chrome-devtools`, `claude-in-chrome`), driving Chrome via raw HTTP/WebSocket, or falling back to other browsers. Shipped three diagnostic/recovery helper scripts and an upgrade path for existing installs.
+
+## Key Accomplishments
+
+- New "Tool Selection" + "On activation" preflight sections in SKILL.md explicitly naming forbidden lookalike MCPs.
+- Three new helper scripts on PATH: `chrome-cdp-health`, `chrome-cdp-restart`, `chrome-cdp-tabs`. Diagnostic and recovery only — deliberately NOT action helpers (see Decisions).
+- Hardcoded launchd label `is.ars.chrome-cdp` (renamed plist from `com.example.chrome-cdp.plist`) so troubleshooting commands work without per-machine substitution.
+- `install-cft.sh --symlinks-only` flag for upgrading existing CfT installs without re-downloading.
+- INSTALL.md "Upgrading from v1.3" block — existing users must unload + remove the old plist before loading the new one, otherwise both LaunchAgents race for port 9222.
+
+## Changes Made
+
+- Created: `skills/chrome-browser/scripts/chrome-cdp-{health,restart,tabs}.sh`
+- Created: `.changeset/chrome-browser-tool-selection-hardening.md`
+- Modified: `skills/chrome-browser/{SKILL,INSTALL,README}.md`, `scripts/install-cft.sh`
+- Renamed: `com.example.chrome-cdp.plist` → `is.ars.chrome-cdp.plist`
+
+## Decisions
+
+- **Prose-only, not a hook gate.** A PreToolUse gate blocking `mcp__playwright__browser_*` would also break the user's separate work-flow Playwright usage. Hardened the skill instructions instead, accepting that prose-only is rule-not-gate per the repo's "gates over rules" principle.
+- **Ship diagnostic helpers, NOT action helpers.** `health`, `restart`, `tabs` are orthogonal to Playwright — they answer questions Playwright can't (is CDP alive? is the launchd job loaded?). Shipping action helpers (`goto`, `click`, `eval`) would re-create the exact tool-selection problem we're solving: a sibling tool surface for agents to flee to when Playwright errors transiently.
+- **Rejected: bundling a custom MCP server with the plugin.** Technically supported via `.claude-plugin/.mcp.json`, but would double the tool surface and conflict with the host environment's Playwright plugin (especially in Cursor). Would recreate the exact problem under a different name.
+- **Hardcoded label, not configurable.** Letting users customize `Label` means troubleshooting prose has to say "your-label-here". Picking `is.ars.chrome-cdp` and making prose concrete is more valuable than per-user flexibility.
+- **`chrome-cdp-tabs` filters `type=="page"` by default.** CDP `/json` also returns service workers + background pages. Default to the user's mental model ("tabs"), expose everything via `--all`.
+- **`chrome-cdp-health` extracts `webSocketDebuggerUrl` via python3 with `grep`/`sed` fallback.** macOS ships python3, but if it's ever missing the script should still distinguish "missing field" (exit 2 with informative message) from "wrong host" (the original exit-2 case).
+
+## Empirical Basis
+
+Episodic-memory search surfaced two concrete prior incidents that drove specific defenses:
+
+- 2026-01-18 (home-workspace): agent confused `claude-in-chrome` MCP with Playwright MCP, silently failed `browser_tabs`, fell back to navigating `example.com`. → motivates explicit forbidden-MCP list.
+- 2026-05-02 (FunG worktree): agent bypassed Playwright entirely and ran `curl http://127.0.0.1:9222/json` to enumerate tabs. → motivates the "never drive via raw HTTP/WebSocket" rule and the sanctioned `chrome-cdp-tabs` helper.
+
+Corpus stats from a cross-machine audit (~109 sessions, ~1754 hits): zero Safari/Firefox fallback — failures cluster in the first ~30–60s after skill activation, hence the on-activation preflight.
+
+## Known Gaps / Follow-ups
+
+- [ ] **Cursor MCP config path:** Cursor loads MCPs from a different config than Claude Code CLI and may not honor plugin `.mcp.json` at all. INSTALL.md does not yet address this. Worth a "Cursor-specific" subsection if usage there grows.
+- [ ] **Playwright MCP namespace caveat documented** (`mcp__playwright__*` vs `mcp__plugin_<plugin>_playwright__*`) but no automated probe — preflight relies on the agent recognizing either form.
+
+## Next Steps
+
+- [ ] Push commit, open PR, walk through Changesets release flow.
+- [ ] After release, retest on Cursor environment to confirm the prose-only hardening + helpers reduce the failure modes that triggered this work.

--- a/skills/chrome-browser/INSTALL.md
+++ b/skills/chrome-browser/INSTALL.md
@@ -15,27 +15,35 @@ ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh
 
 # Or a specific version
 ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147
+
+# Or skip the download and just refresh helper symlinks (when upgrading the skill on a machine
+# that already has CfT installed)
+${CLAUDE_SKILL_DIR}/scripts/install-cft.sh --symlinks-only
 ```
 
 CfT installs to `~/.local/Applications/Google Chrome for Testing.app`. It has its own bundle ID (`com.google.chrome.for.testing`) and a distinctive "TEST" badge icon — macOS treats it as a separate app in the Dock.
 
-The script also creates a stable launcher entry point at `~/.local/bin/launch-chrome-cdp` (symlink → `scripts/launch-chrome-cdp.sh`). If `~/.local/bin` is on your `$PATH`, future sessions can simply call `launch-chrome-cdp` without knowing the skill's installation path.
+The script also installs four helper symlinks into `~/.local/bin/` (→ `scripts/*.sh`): `launch-chrome-cdp`, `chrome-cdp-health`, `chrome-cdp-restart`, `chrome-cdp-tabs`. If `~/.local/bin` is on your `$PATH`, future sessions can call them directly without knowing the skill's installation path.
 
-## 2. Create a launchd plist
+## 2. Install the launchd plist
 
-Use `com.example.chrome-cdp.plist` as a template. Customize:
+The plist label is hardcoded as `is.ars.chrome-cdp` so the skill's troubleshooting commands work without machine-specific lookups. Copy it as-is and only adjust `ProgramArguments` paths.
 
-- **Label** — change `com.example.chrome-cdp` to something unique (e.g. `com.yourname.chrome-cdp`)
-- **ProgramArguments** — replace `/Users/USERNAME/` with your actual home directory
-
-Install:
+> **Upgrading from v1.3 or earlier?** The old plist used label `com.example.chrome-cdp`. Unload and remove it before loading the new one — otherwise both LaunchAgents race for port 9222 and neither starts cleanly:
+>
+> ```bash
+> launchctl unload ~/Library/LaunchAgents/com.example.chrome-cdp.plist 2>/dev/null || true
+> rm -f ~/Library/LaunchAgents/com.example.chrome-cdp.plist
+> ```
 
 ```bash
-# Copy customized plist to LaunchAgents
-cp com.yourname.chrome-cdp.plist ~/Library/LaunchAgents/
+# Copy plist into LaunchAgents, substituting $HOME for the /Users/USERNAME placeholders
+sed "s|/Users/USERNAME|$HOME|g" \
+  ${CLAUDE_SKILL_DIR}/is.ars.chrome-cdp.plist \
+  > ~/Library/LaunchAgents/is.ars.chrome-cdp.plist
 
 # Load the agent (auto-starts on login from now on)
-launchctl load ~/Library/LaunchAgents/com.yourname.chrome-cdp.plist
+launchctl load ~/Library/LaunchAgents/is.ars.chrome-cdp.plist
 ```
 
 ## 3. Configure Playwright MCP
@@ -49,8 +57,8 @@ Restart Claude Code to pick up the new MCP server.
 ## 4. Verify
 
 ```bash
-# CDP responding
-curl -s http://127.0.0.1:9222/json/version | python3 -m json.tool
+# CDP responding (exit 0 = alive on local endpoint)
+chrome-cdp-health
 
 # launchd agent loaded
 launchctl list | grep chrome-cdp
@@ -58,9 +66,8 @@ launchctl list | grep chrome-cdp
 # CfT installed
 ls ~/.local/Applications/Google\ Chrome\ for\ Testing.app/
 
-# Launcher symlink on PATH
-which launch-chrome-cdp     # → ~/.local/bin/launch-chrome-cdp
-readlink "$(which launch-chrome-cdp)"  # points into the skill scripts/ directory
+# Helpers on PATH (installed by install-cft.sh)
+which launch-chrome-cdp chrome-cdp-health chrome-cdp-restart chrome-cdp-tabs
 
 # After restarting Claude Code, test Playwright MCP tools:
 # browser_navigate, browser_snapshot, browser_tabs should all work
@@ -68,7 +75,7 @@ readlink "$(which launch-chrome-cdp)"  # points into the skill scripts/ director
 
 ## Post-setup
 
-- **Disable old browser extensions** (e.g. claude-in-chrome) in Claude Code settings to avoid conflicts
+- **Disable lookalike browser MCPs** (e.g. `claude-in-chrome` — deprecated, replaced by this skill; or `chrome-devtools` if loaded) in your Claude Code MCP config to avoid tool-selection confusion
 - **Log into sites** in the dedicated Chrome window — cookies persist across restarts
 - **Verify after reboot** — `launchctl list | grep chrome-cdp` and `curl -s http://127.0.0.1:9222/json/version`
 - **Update CfT** — re-run `install-cft.sh` when you want a newer Chrome version

--- a/skills/chrome-browser/README.md
+++ b/skills/chrome-browser/README.md
@@ -25,10 +25,13 @@ chrome-browser/
 ├── SKILL.md                      # Lean overview, architecture, decisions
 ├── README.md                     # This file
 ├── INSTALL.md                    # Full setup checklist
-├── com.example.chrome-cdp.plist  # Template launchd plist
+├── is.ars.chrome-cdp.plist       # launchd plist (label hardcoded — copy as-is)
 └── scripts/
     ├── launch-chrome-cdp.sh      # Idempotent launch script (prefers CfT, falls back to Chrome)
-    └── install-cft.sh            # Downloads and installs Chrome for Testing
+    ├── chrome-cdp-health.sh      # Liveness + endpoint check (exit 0/1/2)
+    ├── chrome-cdp-restart.sh     # Kickstart launchd-managed Chrome
+    ├── chrome-cdp-tabs.sh        # Read-only tab listing
+    └── install-cft.sh            # Downloads CfT + symlinks helpers onto $PATH
 ```
 
 ## Validated On
@@ -39,6 +42,7 @@ chrome-browser/
 | lima | 2026-03-07 | Working (launchd, Playwright MCP verified) |
 | lima | 2026-03-30 | v1.1.0: Chrome for Testing + ergonomic flags |
 | mac-zrh | 2026-05-03 | v1.3.0: tool-selection + page gotchas docs, `~/.local/bin/launch-chrome-cdp` symlink, expanded troubleshooting |
+| katoz | 2026-05-09 | v1.4.0: hardcoded launchd label, helper scripts (`chrome-cdp-{health,tabs,restart}`), `--symlinks-only`, on-activation preflight |
 
 ## Dependencies
 

--- a/skills/chrome-browser/SKILL.md
+++ b/skills/chrome-browser/SKILL.md
@@ -19,6 +19,33 @@ A dedicated headed Chrome for Testing (CfT) instance with CDP for Playwright MCP
 - Headed so the user can log into sites manually; Playwright shares the session
 - launchd auto-starts on login, restarts on crash
 
+## Tool Selection
+
+This skill drives Chrome **only** through Playwright MCP attached to `127.0.0.1:9222`.
+
+**Do NOT use these lookalike MCPs even if they are loaded in the session:**
+
+- `mcp__chrome-devtools__*` — different MCP. Using it mixes tool surfaces and breaks the single-source-of-truth model this skill relies on. Typical failure: agent silently switches MCPs after a transient Playwright error and continues against an unrelated browser context.
+- `mcp__claude-in-chrome__*` — **deprecated predecessor; this skill replaces it.** If it shows up loaded somewhere, the config is stale — ignore it and use Playwright against `127.0.0.1:9222`.
+
+If Playwright MCP isn't loaded, **stop and tell the user** — do not silently switch to a sibling MCP, and do not drive the browser via raw `curl`/CDP-WebSocket (see "Working with pages").
+
+The Playwright MCP tools may be exposed under either namespace depending on how it was installed:
+
+- `mcp__playwright__browser_*` — when added via `claude mcp add playwright …` (the INSTALL.md flow).
+- `mcp__plugin_<plugin>_playwright__browser_*` — when loaded as part of a Claude Code plugin.
+
+Either is fine; both attach to the same `127.0.0.1:9222` CDP. The preflight below checks whichever variant is present.
+
+## On activation
+
+Before the first browser action in a session, run a 2-check preflight:
+
+1. **Browser ready:** `chrome-cdp-health` (exit 0). On exit 1 → CDP unreachable, run `launch-chrome-cdp`. On exit 2 → endpoint reachable but `webSocketDebuggerUrl` is not local; the Playwright MCP `--cdp-endpoint` is misconfigured.
+2. **Playwright MCP loaded:** at least one `mcp__*playwright*__browser_*` tool is available (either `mcp__playwright__*` or the plugin-namespaced `mcp__plugin_<plugin>_playwright__*`). If neither is present, stop and tell the user — see Tool Selection.
+
+If either check fails, stop and surface the issue. Do not improvise an alternative.
+
 ## Architecture
 
 ```
@@ -33,16 +60,18 @@ Chrome for Testing (CfT, ~/.local/Applications/)
 ## Quick Reference
 
 ```bash
-# Check CDP
-curl -s http://127.0.0.1:9222/json/version
+# Health / inspect / restart helpers (~/.local/bin/, installed by install-cft.sh)
+chrome-cdp-health         # exit 0 alive, 1 unreachable, 2 endpoint wrong host
+chrome-cdp-tabs           # list open tabs — read-only
+chrome-cdp-restart        # kickstart launchd-managed Chrome (use when CDP hangs)
 
 # Configure Playwright MCP (user-scope, one-time)
 claude mcp add -s user playwright -- npx @playwright/mcp --cdp-endpoint http://127.0.0.1:9222
 
-# Manual launch — prefer the PATH symlink (created by install-cft.sh)
+# Start / ensure Chrome CDP is running (one-shot, idempotent)
 launch-chrome-cdp                                    # ~/.local/bin/launch-chrome-cdp
 
-# Install / update Chrome for Testing (also (re)creates the launcher symlink)
+# Install / update Chrome for Testing (also (re)creates the helper symlinks)
 ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh          # latest stable
 ${CLAUDE_SKILL_DIR}/scripts/install-cft.sh 147      # specific milestone
 ```
@@ -65,10 +94,21 @@ SKILL_DIR="$(dirname "$(find ~/.claude/skills ~/.claude/plugins ~/CODE \
 
 ## Using the browser via Playwright MCP
 
-- **Close tabs:** use the `browser_tabs` tool (close action). Playwright `page.close()` does NOT work over CDP — it fails silently.
+- **Inspect and close tabs:** use the `browser_tabs` tool (no action = list; `close` action = close). Playwright `page.close()` does NOT work over CDP — it fails silently.
 - **One tab at a time:** close each tab when done. If 10+ tabs accumulate, close all and start fresh.
 - **Sequential, not parallel:** browser tool calls in parallel race the same Chrome instance. Wait for the previous call to settle before issuing the next.
-- **Verify you're talking to the local CDP:** `curl -s http://127.0.0.1:9222/json/version | jq .webSocketDebuggerUrl` should return a `ws://127.0.0.1:9222/...` URL. If it points at another host, the MCP config has been pointed at a remote CDP — fix it before doing anything else.
+- **Verify you're talking to the local CDP:** run `chrome-cdp-health`. Exit 0 = alive on `127.0.0.1:9222`; exit 2 = endpoint reachable but `webSocketDebuggerUrl` points elsewhere (the MCP `--cdp-endpoint` is pointed at a remote host — fix it before doing anything else).
+- **Never drive the browser via raw HTTP/WebSocket against `:9222/json/*`.** Those endpoints are for diagnostics only. For read-only inspection use `chrome-cdp-tabs` or `chrome-cdp-health`. Tab manipulation, navigation, snapshots, and any action go through Playwright MCP — direct CDP calls bypass Playwright's state tracking and break subsequent MCP calls.
+
+### When Playwright MCP errors but CDP is alive
+
+If `mcp__playwright__browser_*` errors but `chrome-cdp-health` returns 0, CDP is healthy and Playwright is the problem. Restart launchd-managed Chrome and retry the same Playwright call:
+
+```bash
+chrome-cdp-restart
+```
+
+**Never** switch to `mcp__chrome-devtools__*` or `mcp__claude-in-chrome__*` as a workaround. The fix is always to restore CDP, not to change MCPs. If CDP itself is dead, see Troubleshooting → "CDP unreachable" below.
 
 ## Working with pages
 
@@ -96,26 +136,22 @@ SKILL_DIR="$(dirname "$(find ~/.claude/skills ~/.claude/plugins ~/CODE \
 
 ## Troubleshooting
 
-**CDP unreachable** (`curl -s http://127.0.0.1:9222/json/version` is empty or errors):
+**CDP unreachable** (`chrome-cdp-health` exit 1):
 
 1. `launchctl list | grep chrome-cdp` — is the launchd agent loaded?
 2. `pgrep -f chrome-cdp-profile` — is a Chrome process actually running?
-3. **Process exists but CDP is dead** (the "running but hung" case): `pkill -f chrome-cdp-profile`, wait 2 s, then `launch-chrome-cdp` (or `${CLAUDE_SKILL_DIR}/scripts/launch-chrome-cdp.sh`).
+3. **Process exists but CDP is dead** (the "running but hung" case): `chrome-cdp-restart` (when launchd-loaded), or `pkill -f chrome-cdp-profile` + `launch-chrome-cdp` if the launchd agent isn't loaded.
 4. **Launchd shows non-zero exit** in `launchctl list`: check the stdout/stderr paths defined in your plist.
 
-**CDP reaches the wrong machine:**
-
-```bash
-curl -s http://127.0.0.1:9222/json/version | jq .webSocketDebuggerUrl
-```
-
-The URL must start with `ws://127.0.0.1:9222/`. If it points at a different host, the Playwright MCP `--cdp-endpoint` is wrong — re-run the `claude mcp add` line in Quick Reference.
+**CDP reaches the wrong machine** (`chrome-cdp-health` exit 2): `webSocketDebuggerUrl` does not start with `ws://127.0.0.1:9222/`. The Playwright MCP `--cdp-endpoint` has been pointed at a remote host — re-run the `claude mcp add` line in Quick Reference.
 
 **Profile lock errors:** zombie Chrome holding `~/.cache/chrome-cdp-profile`. `pkill -f chrome-cdp-profile`, wait 2 s, relaunch.
 
 **Cloudflare challenges:** wait, don't retry. Real blocks are very rare; they need a fresh IP, not another browser restart.
 
 **CfT update:** run `${CLAUDE_SKILL_DIR}/scripts/install-cft.sh` to download/install the latest stable version (it also refreshes the `launch-chrome-cdp` symlink).
+
+**Lost session after CfT update:** the persistent profile at `~/.cache/chrome-cdp-profile` may lose stored cookies/logins after a Chrome for Testing version bump. This is one-time per upgrade — re-login manually in the headed browser, no profile reset needed. Warn the user before any destructive `pkill`/profile-clear, since they may need the existing tab state for re-auth.
 
 ## Setup
 

--- a/skills/chrome-browser/is.ars.chrome-cdp.plist
+++ b/skills/chrome-browser/is.ars.chrome-cdp.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.example.chrome-cdp</string>
+    <string>is.ars.chrome-cdp</string>
 
     <!-- Install CfT first: scripts/install-cft.sh -->
     <key>ProgramArguments</key>

--- a/skills/chrome-browser/scripts/chrome-cdp-health.sh
+++ b/skills/chrome-browser/scripts/chrome-cdp-health.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check whether Chrome CDP is reachable on the local debugging port.
+#
+# Exit codes:
+#   0 — CDP responding on 127.0.0.1:9222 with a local webSocketDebuggerUrl
+#   1 — CDP not responding (Chrome not running, or wrong port)
+#   2 — CDP responding but webSocketDebuggerUrl points elsewhere (misconfigured)
+
+PORT=9222
+URL="http://127.0.0.1:${PORT}/json/version"
+
+response="$(curl -fsS --max-time 2 "${URL}" 2>/dev/null)" || {
+  echo "CDP unreachable on 127.0.0.1:${PORT} — run launch-chrome-cdp" >&2
+  exit 1
+}
+
+# Extract webSocketDebuggerUrl. Prefer python3 (handles JSON escaping properly);
+# fall back to grep/sed so the script works without python3 installed.
+ws_url=""
+if command -v python3 >/dev/null 2>&1; then
+  ws_url="$(printf '%s' "${response}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("webSocketDebuggerUrl",""))' 2>/dev/null || true)"
+fi
+if [[ -z "${ws_url}" ]]; then
+  ws_url="$(printf '%s' "${response}" | grep -o '"webSocketDebuggerUrl":"[^"]*"' | sed 's/"webSocketDebuggerUrl":"\(.*\)"/\1/')"
+fi
+
+if [[ -z "${ws_url}" ]]; then
+  echo "CDP responded on 127.0.0.1:${PORT} but no webSocketDebuggerUrl in payload — unexpected response." >&2
+  exit 2
+fi
+
+if [[ "${ws_url}" != ws://127.0.0.1:${PORT}/* ]]; then
+  echo "CDP responding but webSocketDebuggerUrl is not local: ${ws_url}" >&2
+  echo "Playwright MCP --cdp-endpoint is likely misconfigured." >&2
+  exit 2
+fi
+
+printf '%s\n' "${response}"

--- a/skills/chrome-browser/scripts/chrome-cdp-restart.sh
+++ b/skills/chrome-browser/scripts/chrome-cdp-restart.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restart the launchd-managed Chrome CDP browser when the process is alive but
+# CDP itself is hung (the "running but stuck" case), or when Playwright errors
+# repeatedly while CDP otherwise responds.
+#
+# Wraps `launchctl kickstart -k` with the hardcoded service label so callers
+# don't have to remember it.
+#
+# Exit codes:
+#   0 — kickstart issued; CDP came back within timeout
+#   1 — launchd job not loaded (run setup; see INSTALL.md)
+#   2 — kickstart issued but CDP did not return within timeout
+
+LABEL="is.ars.chrome-cdp"
+PORT=9222
+TIMEOUT_SECONDS=15
+
+if ! launchctl print "gui/$(id -u)/${LABEL}" >/dev/null 2>&1; then
+  echo "launchd job '${LABEL}' is not loaded." >&2
+  echo "Either run 'launch-chrome-cdp' (one-shot) or follow INSTALL.md to load the plist." >&2
+  exit 1
+fi
+
+echo "Restarting ${LABEL}..."
+launchctl kickstart -k "gui/$(id -u)/${LABEL}"
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+while (( $(date +%s) < deadline )); do
+  if curl -fsS --max-time 1 "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
+    echo "CDP back on 127.0.0.1:${PORT}"
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "CDP did not return within ${TIMEOUT_SECONDS}s after kickstart." >&2
+echo "Check the launchd logs configured in the plist (default: /tmp/chrome-cdp.stderr.log)." >&2
+exit 2

--- a/skills/chrome-browser/scripts/chrome-cdp-tabs.sh
+++ b/skills/chrome-browser/scripts/chrome-cdp-tabs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List open tabs in the CDP-attached Chrome — read-only.
+#
+# Sanctioned alternative to ad-hoc `curl :9222/json` calls when Playwright MCP
+# is unavailable or you want a quick out-of-band peek at browser state. Output
+# is JSON (pretty-printed if jq or python3 is present).
+#
+# Filtered to actual page targets (CDP /json also returns service workers and
+# background pages — those are hidden by default). Pass --all to see everything.
+#
+# This script NEVER closes, navigates, or otherwise mutates browser state — for
+# tab manipulation use Playwright MCP `browser_tabs`.
+#
+# Exit codes:
+#   0 — tabs listed
+#   1 — CDP unreachable
+
+PORT=9222
+URL="http://127.0.0.1:${PORT}/json"
+
+SHOW_ALL=false
+case "${1:-}" in
+  --all) SHOW_ALL=true ;;
+  -h|--help)
+    sed -n '/^# List/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^#$//;s/^# //;/^$/d'
+    exit 0
+    ;;
+  "") ;;
+  *)
+    echo "Unknown flag: $1" >&2
+    echo "Usage: chrome-cdp-tabs [--all]" >&2
+    exit 2
+    ;;
+esac
+
+response="$(curl -fsS --max-time 2 "${URL}" 2>/dev/null)" || {
+  echo "CDP unreachable on 127.0.0.1:${PORT} — run launch-chrome-cdp" >&2
+  exit 1
+}
+
+if command -v jq >/dev/null 2>&1; then
+  if [[ "${SHOW_ALL}" == true ]]; then
+    printf '%s' "${response}" | jq '[.[] | {id, type, title, url}]'
+  else
+    printf '%s' "${response}" | jq '[.[] | select(.type == "page") | {id, type, title, url}]'
+  fi
+elif command -v python3 >/dev/null 2>&1; then
+  printf '%s' "${response}" | python3 -m json.tool
+else
+  printf '%s\n' "${response}"
+fi

--- a/skills/chrome-browser/scripts/install-cft.sh
+++ b/skills/chrome-browser/scripts/install-cft.sh
@@ -5,20 +5,72 @@ set -euo pipefail
 # CfT has its own bundle ID (com.google.chrome.for.testing) and a distinctive
 # icon with a "TEST" badge, so it appears as a separate app in the Dock.
 #
-# Requires: npx (Node.js)
+# Requires: npx (Node.js) — only when downloading; --symlinks-only does not need it.
 # Usage:
-#   install-cft.sh              Install latest stable
-#   install-cft.sh 147          Install specific milestone
-#   install-cft.sh 147.0.7727.24  Install exact version
+#   install-cft.sh                  Install latest stable + refresh helper symlinks
+#   install-cft.sh 147              Install specific milestone + refresh symlinks
+#   install-cft.sh 147.0.7727.24    Install exact version + refresh symlinks
+#   install-cft.sh --symlinks-only  Refresh helper symlinks only (no download)
 
 INSTALL_DIR="$HOME/.local/Applications"
 BIN_DIR="$HOME/.local/bin"
 APP_NAME="Google Chrome for Testing.app"
-VERSION="${1:-stable}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LAUNCHER_SRC="${SCRIPT_DIR}/launch-chrome-cdp.sh"
-LAUNCHER_DEST="${BIN_DIR}/launch-chrome-cdp"
+
+# Helpers to symlink onto $PATH. Each pair is "<source-script>:<bin-name>".
+HELPERS=(
+  "launch-chrome-cdp.sh:launch-chrome-cdp"
+  "chrome-cdp-health.sh:chrome-cdp-health"
+  "chrome-cdp-restart.sh:chrome-cdp-restart"
+  "chrome-cdp-tabs.sh:chrome-cdp-tabs"
+)
+
+install_helper_symlinks() {
+  mkdir -p "${BIN_DIR}"
+  for entry in "${HELPERS[@]}"; do
+    local src="${SCRIPT_DIR}/${entry%%:*}"
+    local dest="${BIN_DIR}/${entry##*:}"
+    if [[ -x "${src}" ]]; then
+      ln -sf "${src}" "${dest}"
+      echo "  ${dest} -> ${src}"
+    else
+      echo "  Warning: ${src} not found or not executable — symlink not created." >&2
+    fi
+  done
+
+  if ! echo ":${PATH}:" | grep -q ":${BIN_DIR}:"; then
+    echo ""
+    echo "Note: ${BIN_DIR} is not on \$PATH. Add it to your shell rc to use the helpers directly."
+  fi
+}
+
+# Parse args
+SYMLINKS_ONLY=false
+VERSION="stable"
+case "${1:-}" in
+  --symlinks-only)
+    SYMLINKS_ONLY=true
+    ;;
+  -h|--help)
+    sed -n '/^# Download/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^#$//;s/^# //;/^$/d'
+    exit 0
+    ;;
+  -*)
+    echo "Unknown flag: $1" >&2
+    echo "Usage: install-cft.sh [VERSION | --symlinks-only | -h | --help]" >&2
+    exit 2
+    ;;
+  *)
+    VERSION="${1:-stable}"
+    ;;
+esac
+
+if [[ "${SYMLINKS_ONLY}" == true ]]; then
+  echo "Refreshing helper symlinks only (no CfT download)..."
+  install_helper_symlinks
+  exit 0
+fi
 
 if ! command -v npx &>/dev/null; then
   echo "Error: npx not found. Install Node.js first." >&2
@@ -60,17 +112,8 @@ echo ""
 echo "Binary: ${INSTALL_DIR}/${APP_NAME}/Contents/MacOS/Google Chrome for Testing"
 echo ""
 
-# Create / refresh the launcher symlink so cold sessions can find it on PATH.
-if [[ -x "${LAUNCHER_SRC}" ]]; then
-  mkdir -p "${BIN_DIR}"
-  ln -sf "${LAUNCHER_SRC}" "${LAUNCHER_DEST}"
-  echo "Launcher symlink: ${LAUNCHER_DEST} -> ${LAUNCHER_SRC}"
-  if ! echo ":${PATH}:" | grep -q ":${BIN_DIR}:"; then
-    echo "  Note: ${BIN_DIR} is not on \$PATH. Add it to your shell rc to use 'launch-chrome-cdp' directly."
-  fi
-else
-  echo "Warning: launcher script not found at ${LAUNCHER_SRC} — symlink not created." >&2
-fi
+# Create / refresh helper symlinks so cold sessions can find them on $PATH.
+install_helper_symlinks
 
 echo ""
-echo "Next: update your launchd plist and reload, or run 'launch-chrome-cdp' (or ${LAUNCHER_SRC})"
+echo "Next: install the launchd plist (see INSTALL.md), or run 'launch-chrome-cdp' for a one-shot session."


### PR DESCRIPTION
## Summary

Hardens the `chrome-browser` skill against recurring failure modes observed across many sessions: agents silently switching to lookalike MCPs (`chrome-devtools`, `claude-in-chrome`), driving Chrome via raw HTTP/WebSocket, or falling back to other browsers. Ships three diagnostic/recovery helper scripts, hardcodes the launchd label, and documents the v1.3 → v1.4 upgrade path.

## Key changes

- **SKILL.md** — new `Tool Selection` + `On activation` preflight sections; explicit forbidden-MCP list; raw HTTP/WebSocket browser driving forbidden; plugin-namespace caveat (`mcp__playwright__*` vs `mcp__plugin_<plugin>_playwright__*`).
- **3 new helpers on PATH** (symlinked by `install-cft.sh`):
  - `chrome-cdp-health` — liveness + endpoint check (exit `0`/`1`/`2`); python3-optional with `grep`/`sed` fallback.
  - `chrome-cdp-restart` — kickstart launchd-managed Chrome when Playwright errors but CDP is alive.
  - `chrome-cdp-tabs` — read-only tab listing; filters `type=="page"` by default, `--all` for everything. Sanctioned alternative to ad-hoc `curl :9222/json`.
  - **Diagnostic/recovery only — NOT action helpers.** Shipping `goto`/`click`/`eval` would re-create the competing-tool-surface problem this PR is solving.
- **Hardcoded launchd label** `is.ars.chrome-cdp` (plist renamed from `com.example.chrome-cdp.plist`) so troubleshooting prose works without per-machine substitution.
- **Upgrade migration:** INSTALL.md §2 now blocks v1.3 users from leaving the old plist loaded — both LaunchAgents would race for port 9222.
- **`install-cft.sh --symlinks-only`** for adopting helpers on machines that already have CfT.

## Why prose-only, not a hook gate

A PreToolUse gate blocking `mcp__playwright__browser_*` would also break the user's separate work-flow Playwright usage elsewhere. Hardened the skill instructions instead — accepting that prose-only is rule-not-gate per the repo's "gates over rules" principle.

## Rejected alternative

Bundling a custom MCP server via `.claude-plugin/.mcp.json` is technically supported but would double the tool surface and conflict with the host environment's Playwright plugin (especially in Cursor) — i.e. recreate the exact problem under a different name.

## Test plan

- [x] `pnpm test` clean
- [x] `bash -n` on all four scripts (3 new + modified `install-cft.sh`)
- [x] `chrome-cdp-health` against running CfT: exit 0, valid local `webSocketDebuggerUrl`
- [x] `chrome-cdp-tabs` against running CfT: returns only `type=="page"` targets by default
- [x] `chrome-cdp-tabs --help` and `--garbage` exit handling
- [x] `install-cft.sh --help`, `--garbage`, and `--symlinks-only` exit handling
- [ ] On a v1.3 machine: verify the INSTALL.md upgrade block correctly migrates the LaunchAgent without dual-binding port 9222
- [ ] Cursor environment: retest after release to confirm the hardening reduces the failure modes that triggered this work

See `docs/sessionlogs/2026-05-18-chrome-browser-hardening-helpers.md` for the empirical incidents that motivated specific defenses and the full decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
