### PR TITLE
dossier: collapse unpublished dossiers to one current version (#56)

### DIFF
--- a/.changeset/dossier-anti-revision-rule.md
+++ b/.changeset/dossier-anti-revision-rule.md
@@ -1,0 +1,20 @@
+---
+"@eins78/agent-skills": patch
+---
+
+dossier: collapse unpublished dossiers to a single current version (#56)
+
+When a user gives mid-session corrections, the agent previously accumulated document history in the dossier body — "Revision note" blocks, `rev. <date>` date suffixes, and inline "first draft framed X / corrected after feedback" phrasing. That edit history is noise to any reader who wasn't in the authoring session.
+
+- SKILL.md §SYNTHESIZE gains an "Anti-revision rule" bullet: rewrite corrections as present-tense facts; state *why a point matters* rather than *that it was added later*; document history lives in commit messages and the sessionlog.
+- Common Mistakes table gains a "narrating edit history" row.
+- review-checklist.md gains item #9 ("Single current version") with red-flag patterns.
+- The dossier template's header comment block now names the anti-revision rule alongside the section-order rule.
+
+Out of scope: deliberate dated addenda on already-published dossiers.
+
+<!--
+bumps:
+  skills:
+    dossier: patch
+-->

--- a/docs/sessionlogs/2026-06-30-dossier-anti-revision-rule.md
+++ b/docs/sessionlogs/2026-06-30-dossier-anti-revision-rule.md
@@ -1,0 +1,55 @@
+# Dossier — anti-revision rule (#56)
+
+**Date:** 2026-06-30
+**Source:** Claude Code (Opus 4.7, 1M)
+**Session:** No compactions · single-shot from a complete user spec
+
+## Summary
+
+Implemented eins78/agent-skills#56 ("dossier skill: add anti-revision rule"). When a user gave mid-session corrections on an unpublished dossier, the agent was accumulating *document history* in the body (Revision-note blocks, `rev. <date>` date suffixes, "first draft framed X / corrected after feedback" phrasing). The skill now instructs the agent to collapse the dossier to a single current version and recast corrections as plain present-tense facts. Branch `worktree-dossier-i56-anti-revision`, PR **#57** opened against `main`.
+
+## Key Accomplishments
+
+- Added "Anti-revision rule" bullet to `skills/dossier/SKILL.md` §SYNTHESIZE (alongside the existing Template-order rule)
+- Added "Narrating edit history in the body" row to the SKILL.md Common Mistakes table
+- Added item **#9 Single current version (no edit history in the body)** to `skills/dossier/references/review-checklist.md` with the standard What/Why/Good/Red-flags structure
+- Extended the `templates/dossier.md` header HTML comment to name the anti-revision rule alongside the section-order rule
+- Bumped `skills/dossier/README.md` item count `8 → 9` in two places (tree comment + Testing step 5)
+- Wrote `.changeset/dossier-anti-revision-rule.md` at patch level (1.1.0 → 1.1.1) with the `bumps:` block
+
+## Changes Made
+
+- Modified: `skills/dossier/SKILL.md`
+- Modified: `skills/dossier/references/review-checklist.md`
+- Modified: `skills/dossier/templates/dossier.md`
+- Modified: `skills/dossier/README.md`
+- Created: `.changeset/dossier-anti-revision-rule.md`
+
+Commit `6267f10`, +46 / -2 lines across 5 files.
+
+## Decisions
+
+- **`patch` not `minor` bump.** The change adds a new SYNTHESIZE bullet, a new Common Mistakes row, *and* a brand-new review-checklist item (#9). By a strict reading of CLAUDE.md's versioning rules ("minor = new sections / expanded coverage"), this could justify `minor`. Chose `patch` because the issue is framed as a bug-fix — an existing-rule-was-missing-and-agents-drifted clarification, not a new dimension of dossier behavior. Confirmed with the user via AskUserQuestion before exiting plan mode.
+- **No new hook.** The skill's README documents a 2026-04-18 polish pass that removed six overfit grep hooks because their patterns were specific to the a11y-extension session and missed equivalent patterns in other dossier styles. Adding `dossier-anti-revision.sh` would re-create that anti-pattern. The rule lives in prose; the review-checklist item #9 is the enforcement surface. The "judgement, not grep" pattern is now load-bearing for the skill's design.
+- **Anti-revision bullet placed next to the Template-order rule** in §SYNTHESIZE — both are "how the body of the dossier should read" rules and form a natural cluster, before the Ballot subsection.
+- **Header-comment extension over a separate template block.** The dossier template already has a section-order rule comment at the top; adding a parallel paragraph for the anti-revision rule reinforces the pattern instead of adding a third surface. Avoided putting the rule in any of the `<!-- REQUIRED -->` annotations, which are about per-section structure, not document-wide style.
+
+## Verification
+
+- `pnpm install` (worktree had no `node_modules`) — installed cleanly via postinstall (skills add)
+- `pnpm test` — exit 0, `dossier` listed in the skills CLI parse output
+- `pnpm run validate` — `All skills valid (0 warning(s))`
+- `git diff --stat` — 4 modified files + 1 new changeset, doc-only, no hooks/`package.json`/version files touched manually
+
+## Plan Reference
+
+- Plan: `~/.claude/plans/address-eins78-agent-skills-issue-56-tidy-ripple.md`
+- Plan was written and approved in plan mode; executed exactly as written. No deviations.
+
+## Out of Scope (per issue)
+
+Deliberate dated addenda on already-published dossiers — that case stays valid and was explicitly excluded both in the issue and in the new SKILL.md/checklist text.
+
+## Next Steps
+
+- Await PR #57 review. Once merged, the changesets/action will open a "Version Packages" PR bumping dossier to `1.1.1` and the plugin via the `bumps:` block.

--- a/skills/dossier/README.md
+++ b/skills/dossier/README.md
@@ -37,7 +37,7 @@ dossier/
 ├── README.md                         # This file
 ├── references/
 │   ├── sources-by-domain.md          # Domain → source mapping (13 domains)
-│   └── review-checklist.md           # Reviewer audit checklist (8 items)
+│   └── review-checklist.md           # Reviewer audit checklist (9 items)
 └── templates/
     └── dossier.md                    # Report template with REQUIRED/OPTIONAL sections
                                       # (ballot template moved to skills/ballot/)
@@ -61,7 +61,7 @@ To verify the skill works:
 2. **Preflight test:** Give an ambiguous request ("look into the AI space") — the skill should ask for clarification before starting research
 3. **Template test:** Check that a produced dossier includes all REQUIRED sections (Key Facts, Key Concepts, Management Summary, Evaluations, Sources)
 4. **Ballot filename gate:** Write a file named `DOSSIER-Test-BALLOT.md` (no reviewer) — the `ballot-filename.sh` hook fires, stderr reports the pattern mismatch, exit code 2.
-5. **Review-checklist pass:** After delivering a dossier, walk through `references/review-checklist.md` — each of the 8 items should be actionable against the finished dossier.
+5. **Review-checklist pass:** After delivering a dossier, walk through `references/review-checklist.md` — each of the 9 items should be actionable against the finished dossier.
 6. **Ballot test:** Ask for a comparison requiring a decision — verify the `ballot` skill's per-reviewer template is used.
 7. **Session test:** After dossier delivery, ask a follow-up question — verify session stays open.
 

--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -73,6 +73,7 @@ Write dossier using `${CLAUDE_SKILL_DIR}/templates/dossier.md`:
 - **Cite factual claims** with clickable reference-link syntax: `claim [S1][ref-S1]` where each citation token (`S1`, `G6`, `R1`, `O3` — pick a consistent category-prefix scheme) has a matching `[ref-S1]: https://...` definition at the end of §Sources. The raw markdown preserves the `[S1]` bracket token for anyone reading the file directly; the rendered link reads as `S1` and clicks through to the URL. Inline `([text](url))` also works for one-off sources. Bar: "could someone verify this?". If your target renderer supports them, the footnote form `[^S1]` is lighter — see `${CLAUDE_SKILL_DIR}/references/review-checklist.md` (citation-integrity) for the portability trade-off.
 - **Source categories** adapt to domain (see template).
 - **Template-order rule.** Glossary stays at the top; Sources stay at the end. The asymmetry is deliberate — glossary is read-support (before), sources are trust-support (after). Do not move glossary to the appendix by analogy with sources.
+- **Anti-revision rule.** An in-progress / unpublished dossier reads as a single current version. No "Revision note" block, no `rev. <date>` suffix on the date line, no "first draft framed X / corrected after feedback" phrasing in the body. When you receive corrections mid-session, **rewrite** the affected lines as plain present-tense facts — don't append a changelog. Keep a point if it is load-bearing for the conclusion, but state *why it matters* (`X was considered because Y`), not *that it was added later* (`edited to also consider X because Y was raised`). Document history belongs in commit messages and the sessionlog. (Deliberate dated addenda on already-published dossiers are a different case and out of scope here.) Reviewed via `${CLAUDE_SKILL_DIR}/references/review-checklist.md` (single-current-version item).
 
 **Ballot** (when decisions happen async — reviewed over chat, on a PR, after the session ends): use the `ballot` skill. Works for multi-reviewer panels and single async deciders alike. Template at `skills/ballot/templates/ballot-per-reviewer.md`; conventions at `skills/ballot/SKILL.md`.
 
@@ -119,6 +120,7 @@ Everything else is reviewed by checklist, not by grep. Earlier iterations shippe
 | Generic recommendations | Tailor to THIS user's context and infrastructure |
 | Bare product names without URLs | Hyperlink every entity on first mention |
 | Same source categories every time | Adapt to domain (see `references/sources-by-domain.md`) |
+| Narrating edit history in the body | Collapse to one current version; recast research-driven points as facts, not as a changelog. Reviewed in the checklist (single-current-version item) |
 | Ending or re-starting session after delivery | Stay open — auto-compact handles context |
 
 For ballot-specific mistakes (anti-options, pre-ticked checkboxes, cover-block archaeology, single-file two-column ballots, reconciliation placement), see `skills/ballot/SKILL.md` §Common Mistakes.

--- a/skills/dossier/references/review-checklist.md
+++ b/skills/dossier/references/review-checklist.md
@@ -147,6 +147,22 @@ Evidence of intent: the author picked one category-prefix scheme (say, `S` for a
 
 ---
 
+## 9. Single current version (no edit history in the body)
+
+**What to check.** The dossier reads as one current version. No "Revision note" block at the top, no `rev. YYYY-MM-DD` suffix on the date line, no inline phrasing that narrates the document's editing history ("first draft framed…", "corrected after feedback", "earlier version over-weighted…"). Corrections received mid-session have been folded back into the body as plain present-tense facts.
+
+**Why it matters.** A reader who wasn't in the authoring session does not care how the conclusion was reached edit-by-edit; they want the current facts and reasoning. Edit-history narration looks thorough but it is just noise — it makes the dossier longer, harder to scan, and signals that the author hasn't yet decided what the final version is. Document history belongs in version control (commit messages) and the sessionlog, not in the dossier body.
+
+**What good looks like.** When a load-bearing point was added late, it is phrased as `X was considered because Y` — the *reasoning* — not `edited to also consider X because Y was later raised as a critical constraint` — the *editing history*. The dossier could be handed to a fresh reader who would never know it had been revised. (This applies to unpublished / in-progress dossiers only. A deliberate dated addendum on an already-published dossier is a different case and out of scope.)
+
+**Red flags.**
+- A "Revision note" / "Changelog" / "Edits" block at the top of the dossier (or any H2 with that role).
+- A `rev. YYYY-MM-DD` suffix appended to the Date line, or a "(updated to…)" parenthetical.
+- Body phrases like "first draft framed", "earlier version", "corrected after feedback", "previously we said", "originally we recommended", "this dossier was updated to also consider…".
+- A new section whose only justification in prose is "added after reviewer feedback".
+
+---
+
 ## Why this replaced the old grep hooks
 
 Earlier iterations of the dossier skill shipped four grep-based audit hooks: `dossier-citation-audit.sh`, `dossier-forbidden-words.sh`, `dossier-section-order.sh`, and `dossier-dated-claim-scan.sh`. Each encoded a specific failure pattern from the a11y-extension Chrome-Web-Store session: the `[Xn]` citation convention, the OSS-mode forbidden-word list, H2-level glossary headings, and ISO-date patterns.

--- a/skills/dossier/templates/dossier.md
+++ b/skills/dossier/templates/dossier.md
@@ -2,6 +2,12 @@
   Section-order rule (reviewed in references/review-checklist.md):
   Glossary stays at top (read-support); Sources stays at end (trust-support).
   See skills/dossier/SKILL.md §SYNTHESIZE for the asymmetry rationale.
+
+  Anti-revision rule (reviewed in references/review-checklist.md item 9):
+  One current version. No "Revision note" block, no `rev. <date>` suffix on
+  the Date line, no edit-history narration in the body. When corrections
+  come in mid-session, rewrite the affected lines as plain present-tense
+  facts; do not append a changelog. See skills/dossier/SKILL.md §SYNTHESIZE.
 -->
 
 # {Title}


### PR DESCRIPTION
## Summary

Closes #56.

While a dossier is being written within a session — i.e. **before it is finalized / sent out** — it should read as a single, current version. The skill currently lets the agent accumulate *document history* when corrections come in mid-session: a "Revision note" block at the top, a `rev. <date>` suffix on the date line, and inline phrasing like "first draft framed X / corrected after feedback / earlier version over-weighted Y". A reader who wasn't in the authoring session doesn't care how the conclusion was reached edit-by-edit; that history is just noise.

This PR adds an **anti-revision rule** to the dossier skill — purely instructional, no new hook (consistent with the skill's "judgement, not grep" review pattern).

## Changes

- `skills/dossier/SKILL.md` §SYNTHESIZE — new **Anti-revision rule** bullet alongside the existing Template-order rule. Rewrite corrections as present-tense facts; state *why a point matters* (`X was considered because Y`), not *that it was added later* (`edited to also consider X because Y was raised`); document history lives in commit messages and the sessionlog.
- `skills/dossier/SKILL.md` Common Mistakes — new row: *Narrating edit history in the body → collapse to one current version*.
- `skills/dossier/references/review-checklist.md` — new item **#9 Single current version (no edit history in the body)** with What/Why/Good/Red-flags structure matching items 1-8.
- `skills/dossier/templates/dossier.md` — header HTML comment block now also names the anti-revision rule.
- `skills/dossier/README.md` — review-checklist item count bumped 8 → 9 in two places.
- `.changeset/dossier-anti-revision-rule.md` — patch bump (`1.1.0` → `1.1.1`) with the `bumps:` block.

Out of scope: deliberate dated addenda on already-published dossiers — that case stays valid.

## Test plan

- [x] `pnpm test` (skills CLI parse check) — exits 0, dossier listed.
- [x] `pnpm run validate` (frontmatter check) — all skills valid (0 warnings).
- [x] Visual scan: SKILL.md SYNTHESIZE renders, Common Mistakes table column count matches, review-checklist item #9 follows the same four-part structure as items 1-8, template HTML comment well-formed.
- [x] `git diff` shows only documentation changes — no hooks, no `package.json`, no version files manually edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
