### PR TITLE
text-to-speech: remove nested claude --print, dispatch a subagent for L1

### DIFF
--- a/.changeset/20260720-tts-l1-subagent-isolation.md
+++ b/.changeset/20260720-tts-l1-subagent-isolation.md
@@ -1,0 +1,52 @@
+---
+"@eins78/agent-skills": major
+---
+
+`text-to-speech`: remove default nested `claude --print` from the L1 narrative rewrite — dispatch a subagent instead (Finding 2), plus three field-report fixes and ID3 lyrics embedding.
+
+Field report from a fresh-machine run of the podcast/TTS pipeline surfaced
+five issues; four were fixes, one a requested feature.
+
+- **BREAKING — L1 narrative rewrite no longer runs automatically.**
+  `pipeline.py`/`chunk_and_rewrite.py` used to shell out to `claude --print`
+  directly. Run from inside an active Claude Code session, that nested call
+  inherits the session's output style / project `CLAUDE.md` and can leak
+  meta-commentary into the rewrite instead of prose (observed: a literal
+  `★ Insight` block rendered into audio). SKILL.md now instructs the driving
+  agent to dispatch an isolated rewrite subagent (Task/Agent tool), write
+  `narrative.txt`, then call `synth-audio.sh --skip-layer 1`. A bare
+  invocation with no existing `narrative.txt` now fails loudly by default
+  instead of silently falling back to the old behavior; standalone/headless
+  callers with no driving agent opt in via `--allow-inline-llm-rewrite`
+  (isolated with `claude --print --safe-mode`). Verified empirically this
+  session: a subagent dispatched from within an explanatory-output-style
+  session — the exact failure condition — returned clean prose with no
+  leaked commentary.
+- Added `validate_narrative()` in `pipeline.py` as a source-agnostic
+  backstop (applies regardless of whether narrative.txt came from a
+  subagent, a human, or the inline fallback): hard-fails on missing chapter
+  markers when the source has headings, a collapsed word count vs. the
+  source, or known contamination patterns.
+- Updated the stale `claude-sonnet-4-6` default to `claude-sonnet-5` in
+  `pipeline.py`, `chunk_and_rewrite.py`, and `kokoro.sh`.
+- Fixed `synth-audio.sh` always passing `--verify` to the backend regardless
+  of whether the flag was given (`${VERIFY:+--verify}` treated the default
+  `VERIFY=0` as non-empty; now gated on value).
+- `kokoro.sh` now runs an idempotent espeak-ng data-path preflight (macOS):
+  Kokoro's bundled `espeakng_loader` dylib has a compiled-in CI build path
+  that hard-aborts on user machines; the preflight symlinks it to a Homebrew
+  `espeak-ng` build (`$(brew --prefix espeak-ng)`) automatically. Documented
+  `brew install espeak-ng` as a hard dependency.
+- `kokoro.sh` now requires `VIRTUAL_ENV` to be set and fails loudly with the
+  fix instead of letting misaki's background `en-core-web-sm` auto-install
+  fail deep with an unhelpful "No virtual environment found".
+- New: the rendered MP3's ID3 `USLT` frame now embeds the final
+  `narrative.txt` (chapter markers stripped to plain title lines) by
+  default — the spoken text travels inside the file for comparison against
+  the source without a separate artefact. `--no-lyrics` opts out.
+
+<!--
+bumps:
+  skills:
+    text-to-speech: major
+-->

--- a/.changeset/20260720-tts-l1-subagent-isolation.md
+++ b/.changeset/20260720-tts-l1-subagent-isolation.md
@@ -32,11 +32,13 @@ five issues; four were fixes, one a requested feature.
 - Fixed `synth-audio.sh` always passing `--verify` to the backend regardless
   of whether the flag was given (`${VERIFY:+--verify}` treated the default
   `VERIFY=0` as non-empty; now gated on value).
-- `kokoro.sh` now runs an idempotent espeak-ng data-path preflight (macOS):
-  Kokoro's bundled `espeakng_loader` dylib has a compiled-in CI build path
-  that hard-aborts on user machines; the preflight symlinks it to a Homebrew
-  `espeak-ng` build (`$(brew --prefix espeak-ng)`) automatically. Documented
-  `brew install espeak-ng` as a hard dependency.
+- `kokoro.sh` now runs a probe-first espeak-ng data-path preflight (macOS):
+  it actually exercises `misaki`'s G2P once and only symlinks the bundled
+  `espeakng_loader` dylib to a Homebrew `espeak-ng` build
+  (`$(brew --prefix espeak-ng)`) when that probe fails — verified
+  empirically (byte-identical dylib+data) that the bundled path is not
+  reliably broken everywhere, so the preflight no longer assumes it always
+  is and stays silent when nothing needs fixing.
 - `kokoro.sh` now requires `VIRTUAL_ENV` to be set and fails loudly with the
   fix instead of letting misaki's background `en-core-web-sm` auto-install
   fail deep with an unhelpful "No virtual environment found".
@@ -44,6 +46,14 @@ five issues; four were fixes, one a requested feature.
   `narrative.txt` (chapter markers stripped to plain title lines) by
   default — the spoken text travels inside the file for comparison against
   the source without a separate artefact. `--no-lyrics` opts out.
+- Fixed two bugs a real end-to-end render surfaced (not reachable from
+  isolated component tests): `kokoro_round5.py` was creating a
+  zero-duration chapter for the H1-title-only marker that precedes the
+  first H2 marker with no body of its own, which `inject_chapters.py`'s
+  own duration check correctly rejected; and
+  `inject_chapters.py`'s marker-stripping regex was mashing back-to-back
+  marker titles together with no separator when converting narrative.txt
+  to USLT lyrics text.
 
 <!--
 bumps:

--- a/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
+++ b/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
@@ -1,0 +1,157 @@
+# text-to-speech: L1 subagent isolation + field-report fixes
+
+**Date:** 2026-07-20
+**Source:** Claude Code
+**Session:** Reconstructed from 1 compaction · plan-mode design, then execution
+
+## Summary
+
+Fixed four issues from a fresh-machine field report on the `text-to-speech`
+skill's Kokoro pipeline, plus one feature added mid-session. The headline
+fix (Finding 2) removes the pipeline's default nested `claude --print` call
+and replaces it with SKILL.md-driven subagent dispatch, closing a real
+context-inheritance bug that leaked session output-style commentary into
+rendered audio.
+
+## Key Accomplishments
+
+- **Finding 2 (priority):** redesigned L1 narrative rewrite. Empirically
+  verified the fix works by dispatching a real rewrite subagent from
+  *within this explanatory-output-style session* — the exact failure
+  condition Max hit — and confirmed it returned clean prose with no
+  leaked `★ Insight` block. Added `validate_narrative()` as a
+  source-agnostic backstop and verified all three of its hard-fail paths
+  (missing markers, word-count collapse, contamination denylist) with
+  real `pipeline.py` runs, plus the negative-gate path (no narrative, no
+  opt-in flag → loud failure) and the opt-in inline fallback's `--safe-mode`
+  argv construction (via a stub `claude` binary).
+- **Finding 1:** fixed `synth-audio.sh`'s always-on `--verify` bug; verified
+  both directions with a stub backend that echoes its argv.
+- **Finding 3:** added an idempotent espeak-ng data-path preflight to
+  `kokoro.sh` (macOS), derived from `$(brew --prefix espeak-ng)` rather than
+  a hardcoded prefix. Verified the symlink loop is idempotent and never
+  clobbers a real (non-symlink) file, using a fake dylib since espeak-ng
+  isn't actually installed via brew in this sandbox (confirmed: `brew
+  --prefix` resolves a theoretical path even for uninstalled formulas — the
+  code's `-f` existence check on the actual dylib correctly caught that and
+  fell through to the warning branch).
+- **Finding 4:** added a loud `VIRTUAL_ENV` precondition to `kokoro.sh`
+  (chose loud-fail over silent `sys.prefix` inference, per plan review —
+  `uv run --no-project` can resolve an interpreter that isn't a
+  pip-installable venv). Verified it fires before any pipeline work starts.
+- **Finding 5 (added mid-session, user request):** embedded the final
+  `narrative.txt` (chapter markers stripped to plain title lines) as an ID3
+  `USLT` lyrics frame, alongside the existing CHAP/CTOC injection. Verified
+  via `inject_chapters.py`'s extended self-test (fresh write, idempotent
+  re-inject, marker-stripping) and a standalone-CLI test (default
+  sibling-file detection, `--no-lyrics` suppression).
+- Updated the stale `claude-sonnet-4-6` default to `claude-sonnet-5` (user's
+  choice, via AskUserQuestion) across all three call sites.
+- Confirmed `private-podcast-feed` needed no changes — grepped for every
+  finding pattern, zero matches.
+- `pnpm test` (skill frontmatter validation) passes after all changes.
+
+## Changes Made
+
+- Modified: `skills/text-to-speech/scripts/synth-audio.sh` — F1 fix, F2/F5
+  flag pass-through (`--allow-inline-llm-rewrite`, `--no-lyrics`)
+- Modified: `skills/text-to-speech/scripts/backends/kokoro.sh` — F2 model id
+  + flag pass-through, F3 espeak-ng preflight, F4 VIRTUAL_ENV precondition,
+  F5 flag pass-through
+- Modified: `skills/text-to-speech/scripts/backends/lib/pipeline.py` — F2
+  gate (`--allow-inline-llm-rewrite`), `--safe-mode` on the inline fallback,
+  `validate_narrative()`, model id
+- Modified: `skills/text-to-speech/scripts/backends/lib/chunk_and_rewrite.py`
+  — F2 `--safe-mode`, model id, doc note pointing to subagent-dispatch as
+  the preferred in-session path
+- Modified: `skills/text-to-speech/scripts/backends/lib/inject_chapters.py`
+  — F5: `USLT` frame support, `strip_chapter_markers()`,
+  `read_back_lyrics()`, `--lyrics`/`--no-lyrics` CLI, extended self-test
+- Modified: `skills/text-to-speech/scripts/backends/lib/kokoro_round5.py` —
+  F5: reads `narrative.txt`, threads `lyrics` through to `inject_chapters`
+- Modified: `skills/text-to-speech/SKILL.md` — new L1 subagent-dispatch
+  section, breaking-change callout in Quick Start, F3/F4/F5 dependency and
+  usage docs, version 1.1.0 → 2.0.0
+- Modified: `skills/text-to-speech/README.md` — F3/F4/F5 deps and usage,
+  breaking-change note, changelog notes section
+- Created: `.changeset/20260720-tts-l1-subagent-isolation.md`
+- Created: this sessionlog
+
+## Decisions
+
+- **Gate, don't delete, the inline `claude --print` path** (Finding 2):
+  Max said "get rid of" the nested call but also asked how to handle a
+  standalone run with no driving agent. Resolved by removing it from the
+  *default* path (now a loud failure without `narrative.txt`) but keeping
+  it behind an explicit opt-in flag (`--allow-inline-llm-rewrite`) isolated
+  with `--safe-mode`, default off — surfaced as a stated tradeoff in the
+  plan rather than decided silently.
+- **`--safe-mode` over `--bare` for the inline fallback's isolation flag:**
+  `--bare` also restricts auth to `ANTHROPIC_API_KEY`/`apiKeyHelper` (no
+  OAuth/keychain), which would break most Claude Code subscription users.
+  `--safe-mode` disables the two named inheritance vectors (CLAUDE.md,
+  output styles) plus hooks/plugins/custom agents, while leaving auth/model
+  selection/tools/permissions normal.
+- **`validate_narrative()` as the load-bearing backstop, not a nicety:**
+  subagent context isolation is a behavioral guarantee, confirmed
+  empirically this session but not something checkable statically. The
+  advisor flagged this explicitly — if a subagent path ever does leak
+  session context, this function is what actually stops garbage from
+  reaching the renderer.
+- **Word-count collapse threshold set low (20%), not the initially-drafted
+  40%:** the narrative-chapter-focused prompt legitimately drops tables,
+  code fences, and Sources/References sections, and compresses lists — a
+  40% floor would false-positive on legitimately terse rewrites. 20% still
+  catches "150 words for a 3000-word doc."
+- **Contamination denylist kept small and explicitly incomplete:** targets
+  the exact observed failure (`★`, `Insight ─`, "approve the plan", "The
+  plan is written") at near-zero cost, documented in-code as a
+  supplementary check, not the primary defense (structural checks are).
+- **`claude-sonnet-5` as the new default model id** (user's explicit choice
+  via AskUserQuestion) for the two secondary/fallback L1 paths — the
+  primary path (subagent dispatch) doesn't take a model flag at all, since
+  it uses the session's own model.
+- **Loud `VIRTUAL_ENV` precondition over silent `sys.prefix` inference**
+  (Finding 4, per plan review): `uv run --no-project python` can resolve a
+  uv-managed interpreter that isn't a pip-installable venv, so silent
+  inference risks setting `VIRTUAL_ENV` somewhere `uv pip install` still
+  can't use.
+- **Version bump to 2.0.0 (major), not minor:** removing the default L1
+  auto-rewrite is a breaking change to existing callers — a bare
+  `synth-audio.sh` invocation that previously worked (via the old inline
+  `claude --print`) now fails loudly without a `--skip-layer 1` narrative
+  or the new opt-in flag.
+
+## Plan Reference
+
+- Plan: `~/.claude/plans/you-are-in-a-cheeky-turing.md`
+- Planned: Findings 1–4 from the field report, Finding 2 prioritized with
+  an explicit remove-vs-gate decision surfaced for review; Finding 5 (ID3
+  lyrics) added by the user mid-review, before plan approval, and folded
+  into the same plan file.
+- Executed: full plan as approved, with all five findings implemented and
+  verified by actually running the code (not just claimed) — stub backends
+  for argv inspection, real `pipeline.py` runs for the L1 gate and
+  `validate_narrative()` paths, real `inject_chapters.py` self-tests with
+  ephemeral `mutagen`/`pyyaml` via `uv run --with`, and a live subagent
+  dispatch from within this session as the primary behavioral proof for
+  Finding 2.
+
+## Next Steps
+
+- [ ] Commit all changes and open a PR (Copilot review enabled on
+      `eins78/agent-skills`) — do not self-merge, per instruction.
+- [ ] No full end-to-end Kokoro render was possible in this sandbox
+      (`kokoro`/`misaki`/mutagen aren't installed — by design, the skill
+      doesn't install backend software). Everything up to and including
+      L1 gating, `validate_narrative()`, L2/L3, and ID3 chapter+lyrics
+      injection was verified directly; actual Kokoro-82M speech synthesis
+      was not exercised this session.
+- [ ] Run the review/deliver loop on the PR (per instruction, handled by
+      Max, not this session).
+
+## Repository State
+
+- Branch: `worktree-podcast-tts-fixes`
+- Not yet committed at the time this sessionlog was written — commit and
+  PR creation follow immediately after.

--- a/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
+++ b/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
@@ -139,19 +139,116 @@ rendered audio.
 
 ## Next Steps
 
-- [ ] Commit all changes and open a PR (Copilot review enabled on
-      `eins78/agent-skills`) — do not self-merge, per instruction.
-- [ ] No full end-to-end Kokoro render was possible in this sandbox
-      (`kokoro`/`misaki`/mutagen aren't installed — by design, the skill
-      doesn't install backend software). Everything up to and including
-      L1 gating, `validate_narrative()`, L2/L3, and ID3 chapter+lyrics
-      injection was verified directly; actual Kokoro-82M speech synthesis
-      was not exercised this session.
+- [x] Commit all changes and open a PR (Copilot review enabled on
+      `eins78/agent-skills`) — do not self-merge, per instruction. **PR #65
+      opened.**
+- [x] Close the real-render verification gap on mac-zrh (see follow-up
+      section below) — done, with two additional bugs found and fixed.
 - [ ] Run the review/deliver loop on the PR (per instruction, handled by
       Max, not this session).
+
+## Follow-up: real end-to-end render on mac-zrh + F3 refinement
+
+After PR #65 was opened, Max approved and asked for two follow-ups: (1)
+close the real-audio-verification gap the sandbox couldn't close, using
+mac-zrh's actual Kokoro install; (2) make F3's preflight probe-first
+instead of assuming the bundled espeak-ng data path is always broken.
+
+### Real render
+
+Built a proper `uv venv --python 3.12`, installed
+`kokoro numpy soundfile pyyaml mutagen` into it (reusing the existing
+`~/.cache/huggingface/hub` model cache — no re-download). Ran the actual
+workflow end to end: dispatched a real L1 rewrite subagent (writing
+`narrative.txt` directly, per the SKILL.md workflow) → `synth-audio.sh
+--skip-layer 1` → real Kokoro-82M render on this machine's MPS backend.
+
+Verified on the produced MP3:
+- **(a) Audio renders:** 40.2s duration (`ffprobe`), non-silent
+  (`ffmpeg -af volumedetect`: mean −23.6dB, max −2.4dB — real speech, not
+  digital silence), full-file decode with `ffmpeg -f null -` exits clean
+  (no truncation/corruption).
+- **(b) USLT lyrics frame:** present, and — after the regex fix below —
+  text-matches the marker-stripped `narrative.txt` exactly.
+- **(c) ID3 CHAP/CTOC chapters:** present and correctly timed.
+
+### Two additional bugs found and fixed by doing the real render
+
+Running the actual pipeline (not mocked/isolated tests) surfaced two
+pre-existing bugs neither the original field report nor the sandbox
+verification could have caught:
+
+1. **`kokoro_round5.py` `synth_full()`: zero-duration first chapter.** The
+   narrative-chapter-focused.md convention (and the exact test narrative a
+   real subagent produced, both in this follow-up and earlier in the
+   session) puts the H1-title marker immediately before the first H2
+   marker with no body between them. `synth_full()` appended a
+   `chapters_ms` entry for *every* part with a title, before checking
+   whether that part had any body — so the empty title-only part got a
+   chapter entry pinned at the same `cumulative_samples` position as the
+   next real chapter, producing two chapters at `start_ms=0`, which
+   `inject_chapters.py`'s own duration-must-be-positive check correctly
+   rejected (`ValueError: chapter 0 has non-positive duration: 0..0`).
+   **Fix:** moved the `if not body: continue` check before the
+   `chapters_ms.append(...)`, so a part with no audio can't anchor a
+   chapter. The document title marker is now correctly dropped as a
+   distinct navigable chapter when it has no content of its own (matches
+   how a podcast player would want it — a zero-duration chapter isn't
+   useful either way).
+2. **`inject_chapters.py` `_CHAPTER_MARKER_RE`: back-to-back markers mashed
+   together in lyrics.** The regex (copied from `pipeline.py`'s detection
+   regex, which only needed `match.start()`/`group(1)` and so never
+   noticed) used `\s*$`/`^\s*`, and Python's `\s` matches `\n`. For two
+   adjacent markers separated only by a blank line, the greedy `\s*$` ate
+   the blank line and the next marker's own newline, so after
+   substitution the two titles landed with zero separator:
+   `"The Habit of Small WinsWhy Momentum Matters"`. My original self-test
+   didn't catch this because it only asserted round-trip consistency
+   against `strip_chapter_markers`'s own output, not against a
+   hand-verified expected string. **Fix:** changed the regex to
+   `[ \t]*` on the outer edges (horizontal whitespace only, scoped to the
+   marker's own line) while keeping `\s*` inside the brackets around the
+   title text. Re-verified via a strengthened self-test that hand-writes
+   the expected output for a back-to-back-markers case, and via the real
+   render (lyrics now read back with correct paragraph breaks).
+
+Both fixes were exercised for real: the render failed with the first bug,
+was fixed, re-ran clean; the lyrics text was visibly wrong with the second
+bug, was fixed, and the final MP3's USLT frame now matches
+marker-stripped `narrative.txt` exactly (confirmed via a diff against a
+hand-computed expected string, not just "it didn't crash").
+
+### F3 refinement: probe first, don't assume
+
+Live evidence this session that the bundled espeak-ng data path is **not**
+reliably broken: with byte-identical `espeakng_loader` dylib + data
+(verified via `shasum`) between two venvs, one built at
+`~/tts-tmp-verify/.venv` (short path) worked with zero symlinking, while an
+earlier attempt at a venv nested deep under this session's scratchpad
+directory failed with the exact CI-path error from the original field
+report. Root cause not fully pinned down (plausibly a fixed-size path
+buffer inside older espeak-ng C code, given the failing path was
+~178 chars vs. ~116 for the working one — but not confirmed), and it
+doesn't need to be: the fix is to probe empirically rather than assume
+either way.
+
+`kokoro.sh`'s F3 preflight now runs the actual runtime code path
+(`misaki.espeak`'s import-time init + one real `EspeakFallback` phonemize
+call) in a subprocess. If it succeeds, the preflight does nothing and
+prints nothing — no spurious "espeak-ng not found via Homebrew" warning on
+a machine where nothing is wrong (this was the bug the old
+always-assume-broken version had). Only if the probe fails does it fall
+back to symlinking a Homebrew `espeak-ng` build (or emitting the
+actionable error if none is found), preserving the never-clobber-a-real-file
+guard from before. The real render above is live proof: it ran with zero
+espeak-ng-related output on this machine.
 
 ## Repository State
 
 - Branch: `worktree-podcast-tts-fixes`
-- Not yet committed at the time this sessionlog was written — commit and
-  PR creation follow immediately after.
+- Initial commit: `38fb377` - text-to-speech: remove nested claude --print,
+  dispatch a subagent for L1
+- PR: https://github.com/eins78/agent-skills/pull/65 (open, not merged)
+- Follow-up commit (real-render verification + 3 additional fixes: F3
+  probe-first, chapter-timing bug, lyrics-regex bug) pushed to the same PR
+  branch after this sessionlog update.

--- a/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
+++ b/docs/sessionlogs/2026-07-20-podcast-tts-fixes.md
@@ -243,12 +243,44 @@ actionable error if none is found), preserving the never-clobber-a-real-file
 guard from before. The real render above is live proof: it ran with zero
 espeak-ng-related output on this machine.
 
+## Follow-up: listenable sample MP3 for Max
+
+After PR #65 was updated, Max asked for a short, real sample MP3 to listen
+to and forward. Not a repo change — no commit was made for this step, so
+it's logged here since it would otherwise leave no trace once the session
+clears.
+
+Built a fresh short-path `uv venv` (same approach as the earlier real-render
+follow-up; the previous verification venv had already been cleaned up),
+wrote a ~257-word test doc (H1 + 2 H2 sections, sized to land the rendered
+audio in Max's requested ~1–2 min range), dispatched a real L1 rewrite
+subagent per the SKILL.md workflow, and ran the actual pipeline end to end:
+`narrative.txt` → `synth-audio.sh --skip-layer 1` → real Kokoro-82M render
+→ ID3 chapters + USLT lyrics injected.
+
+**Output:** `/tmp/podcast-sample-2026-07-20.mp3` — 73.3s, ~578KB, `am_puck`
+voice. Verified via `ffprobe`/`ffmpeg -af volumedetect` (non-silent: mean
+−23.5dB, max −1.9dB) and a full clean decode (`ffmpeg -f null -`, no
+corruption). Verified via mutagen read-back: 2 CHAP frames present and
+correctly timed ("Why Momentum Matters" 0:00–0:34, "Three Ways to Build a
+Streak" 0:34–1:13) plus CTOC; USLT lyrics frame present, text matching the
+narrative exactly. This is the first time in the whole engagement that a
+finished, listenable artifact from the fixed pipeline was produced and
+confirmed end to end.
+
+The temporary verification venv (`~/tts-tmp-verify`) was deleted after use,
+per the same pattern as the earlier real-render follow-up — nothing left
+behind except the sample MP3 itself, at the exact path requested.
+
 ## Repository State
 
 - Branch: `worktree-podcast-tts-fixes`
 - Initial commit: `38fb377` - text-to-speech: remove nested claude --print,
   dispatch a subagent for L1
-- PR: https://github.com/eins78/agent-skills/pull/65 (open, not merged)
-- Follow-up commit (real-render verification + 3 additional fixes: F3
-  probe-first, chapter-timing bug, lyrics-regex bug) pushed to the same PR
-  branch after this sessionlog update.
+- Follow-up commit: `d79d33e` - text-to-speech: real end-to-end render
+  verification + F3 probe-first refinement
+- PR: https://github.com/eins78/agent-skills/pull/65 (open, not merged;
+  description updated to reflect both commits)
+- Working tree clean at session end; the sample-MP3 follow-up touched no
+  repo files (output lives at `/tmp/podcast-sample-2026-07-20.mp3`, not
+  committed, per instruction).

--- a/skills/text-to-speech/README.md
+++ b/skills/text-to-speech/README.md
@@ -13,30 +13,67 @@ The current backend is Kokoro-82M; future backends swap in via config.
 - **Kokoro-82M:** `uv pip install kokoro` (hexgrad/kokoro, Apache-2.0)
 - **Python 3.11+** with `uv` (`brew install uv`)
 - **ffmpeg:** `brew install ffmpeg`
-- **mutagen:** `uv pip install mutagen` (ID3 chapter injection)
+- **espeak-ng:** `brew install espeak-ng` — hard dependency of `misaki`'s
+  G2P. The bundled `espeakng_loader` dylib has a compiled-in CI build data
+  path that doesn't exist on user machines and hard-aborts before Python
+  can flush stdout. `kokoro.sh` runs an idempotent preflight (macOS) that
+  symlinks the loader's dylibs to your Homebrew `espeak-ng` build
+  (`$(brew --prefix espeak-ng)`) automatically — but the brew package
+  itself must be installed first. Manual fallback, if the preflight can't
+  find your loader's site-packages dir:
+  ```bash
+  SP=<venv>/lib/python3.12/site-packages/espeakng_loader
+  for d in libespeak-ng.dylib libespeak-ng.1.dylib libespeak-ng.1.52.0.dylib; do
+    ln -sf "$(brew --prefix espeak-ng)/lib/libespeak-ng.dylib" "$SP/$d"
+  done
+  ```
+- **`VIRTUAL_ENV` must be set** in the calling environment before invoking
+  `synth-audio.sh`. `misaki` auto-installs the `en-core-web-sm` spaCy model
+  via `uv pip install` on first use; under `uv run --no-project` with no
+  active `VIRTUAL_ENV` that install fails with "No virtual environment
+  found" (exit 2, no traceback). `kokoro.sh` checks this upfront and fails
+  loudly with the fix instead of letting the render fail deep inside misaki.
+- **mutagen:** `uv pip install mutagen` (ID3 chapter + lyrics injection)
 - **mlx-whisper** (optional, for `--verify`): `uv pip install mlx-whisper`
 
 The skill does NOT install these — caller's responsibility.
 
 ## Usage
 
+**v2.0.0 breaking change:** the L1 narrative rewrite no longer runs
+automatically. A bare invocation with no existing `narrative.txt` now fails
+loudly (see SKILL.md's "L1 Narrative Rewrite" section) instead of silently
+shelling out to `claude --print`, which — run from inside an active Claude
+Code session — could inherit the session's output style/CLAUDE.md and leak
+meta-commentary into the rendered audio. The normal flow is now: the driving
+agent dispatches an isolated subagent to write `narrative.txt`, then calls
+`synth-audio.sh` with `--skip-layer 1`.
+
 ```bash
-# Minimal
-./scripts/synth-audio.sh input.md output.mp3
+# Normal flow: narrative.txt already written by a dispatched subagent
+./scripts/synth-audio.sh input.md output.mp3 --skip-layer 1
 
 # With config file
 cp ./templates/synth-backend.yaml.example ./synth-backend.yaml
-./scripts/synth-audio.sh input.md output.mp3
+./scripts/synth-audio.sh input.md output.mp3 --skip-layer 1
 
 # With Whisper self-check
-./scripts/synth-audio.sh input.md output.mp3 --verify
+./scripts/synth-audio.sh input.md output.mp3 --skip-layer 1 --verify
 
-# Skip L1 rewrite (reuse existing narrative.txt in workdir)
-./scripts/synth-audio.sh input.md output.mp3 --skip-layer 1
+# Standalone/headless fallback: isolated inline `claude --print --safe-mode`
+# for L1 when no driving agent is present to dispatch a subagent
+./scripts/synth-audio.sh input.md output.mp3 --allow-inline-llm-rewrite
+
+# Skip embedding narrative.txt as an ID3 USLT lyrics frame (default: on)
+./scripts/synth-audio.sh input.md output.mp3 --skip-layer 1 --no-lyrics
 ```
 
 The script creates a `<output>.workdir/` directory for intermediates
-(narrative.txt, normalized.txt, kokoro.txt, chapters.json).
+(narrative.txt, normalized.txt, kokoro.txt, chapters.json). Regardless of
+how `narrative.txt` was produced, `pipeline.py` runs `validate_narrative()`
+on it before continuing — hard-failing on missing chapter markers, a
+collapsed word count vs. the source, or known contamination patterns —
+rather than rendering audio from a bad narrative.
 
 ## Origin / Provenance
 
@@ -54,13 +91,32 @@ Five rounds of iteration validated:
 
 | File | Purpose |
 |------|---------|
-| `pipeline.py` | Main orchestrator: L1 (LLM rewrite) → L2 (normalize) → L3a/b/c (prosody prep) |
+| `pipeline.py` | Main orchestrator: L1 (expects pre-written narrative.txt by default; `--allow-inline-llm-rewrite` for an isolated `claude --print --safe-mode` fallback) → `validate_narrative()` → L2 (normalize) → L3a/b/c (prosody prep) |
 | `normalize.py` | L2: dates, versions, abbreviations, symbols |
 | `kokoro_punct.py` | L3c: em-dash chunking, parenthetical → em-dash, ellipsis |
-| `kokoro_round5.py` | Kokoro render: chapter-aware synthesis + ffmpeg MP3 conversion |
-| `inject_chapters.py` | ID3 CHAP/CTOC frame injection via mutagen |
+| `kokoro_round5.py` | Kokoro render: chapter-aware synthesis + ffmpeg MP3 conversion + narrative.txt → USLT lyrics |
+| `inject_chapters.py` | ID3 CHAP/CTOC frame injection + optional USLT lyrics frame, via mutagen |
 | `whisper_transcribe.py` | Whisper-based transcription for `--verify` (Apple MLX) |
-| `chunk_and_rewrite.py` | H2-chunked L1 rewrite for documents >5000 words |
+| `chunk_and_rewrite.py` | Standalone/headless H2-chunked L1 rewrite for documents >5000 words (`--safe-mode` isolated); prefer subagent dispatch when a driving agent is present — see SKILL.md |
+
+## Changelog Notes
+
+**v2.0.0 (Finding 2 redesign):** L1's `claude --print` shelled out from
+inside `pipeline.py`/`chunk_and_rewrite.py`, which — run from inside an
+active Claude Code session — could inherit that session's output style /
+CLAUDE.md and leak meta-commentary into the rewrite (observed: a literal
+`★ Insight` block rendered into audio). Moved L1 orchestration up into
+SKILL.md so the driving agent dispatches an isolated subagent instead; the
+inline `claude --print` path is now opt-in (`--allow-inline-llm-rewrite`,
+`--safe-mode`-isolated) for headless/standalone use. Added
+`validate_narrative()` in `pipeline.py` as a source-agnostic backstop
+(chapter-marker presence, word-count-collapse, and known-contamination
+checks). Updated the stale `claude-sonnet-4-6` default to `claude-sonnet-5`
+across `pipeline.py`, `chunk_and_rewrite.py`, and `kokoro.sh`. Also fixed
+the `--verify` always-on bug in `synth-audio.sh`, added an espeak-ng
+preflight + `VIRTUAL_ENV` precondition in `kokoro.sh`, and added ID3 USLT
+lyrics embedding (narrative.txt travels inside the rendered MP3 for
+debugging). See `docs/sessionlogs/` for the full session record.
 
 ## Future Improvements
 

--- a/skills/text-to-speech/README.md
+++ b/skills/text-to-speech/README.md
@@ -13,14 +13,20 @@ The current backend is Kokoro-82M; future backends swap in via config.
 - **Kokoro-82M:** `uv pip install kokoro` (hexgrad/kokoro, Apache-2.0)
 - **Python 3.11+** with `uv` (`brew install uv`)
 - **ffmpeg:** `brew install ffmpeg`
-- **espeak-ng:** `brew install espeak-ng` — hard dependency of `misaki`'s
-  G2P. The bundled `espeakng_loader` dylib has a compiled-in CI build data
-  path that doesn't exist on user machines and hard-aborts before Python
-  can flush stdout. `kokoro.sh` runs an idempotent preflight (macOS) that
-  symlinks the loader's dylibs to your Homebrew `espeak-ng` build
-  (`$(brew --prefix espeak-ng)`) automatically — but the brew package
-  itself must be installed first. Manual fallback, if the preflight can't
-  find your loader's site-packages dir:
+- **espeak-ng:** conditional dependency — `brew install espeak-ng` as a
+  fallback, not always required. `misaki`'s G2P depends on
+  `espeakng_loader`'s bundled `libespeak-ng.dylib`, whose data-path
+  resolution is not reliably correct on every install — verified this is
+  install-dependent, not universal: a byte-identical dylib+data (same
+  `espeakng_loader` version, confirmed via `shasum`) worked fine from a
+  normally-located venv and hard-aborted from one nested under an unusually
+  long path, on the same machine. `kokoro.sh` runs a probe-first preflight
+  (macOS): it actually exercises `misaki`'s G2P once; if that already
+  works, it does nothing and prints nothing. Only if the probe fails does
+  it symlink the loader's dylibs to a Homebrew `espeak-ng` build
+  (`$(brew --prefix espeak-ng)`) — and only then is the brew package
+  actually required. Manual fallback, if the preflight can't find your
+  loader's site-packages dir or you want to fix it ahead of time:
   ```bash
   SP=<venv>/lib/python3.12/site-packages/espeakng_loader
   for d in libespeak-ng.dylib libespeak-ng.1.dylib libespeak-ng.1.52.0.dylib; do
@@ -116,7 +122,22 @@ across `pipeline.py`, `chunk_and_rewrite.py`, and `kokoro.sh`. Also fixed
 the `--verify` always-on bug in `synth-audio.sh`, added an espeak-ng
 preflight + `VIRTUAL_ENV` precondition in `kokoro.sh`, and added ID3 USLT
 lyrics embedding (narrative.txt travels inside the rendered MP3 for
-debugging). See `docs/sessionlogs/` for the full session record.
+debugging).
+
+A real end-to-end render (not just isolated component tests) surfaced two
+more pre-existing bugs, both fixed: (1) `kokoro_round5.py` was creating a
+zero-duration chapter for the H1-title-only marker that precedes the first
+H2 marker with no body of its own — a part with no audio can no longer
+anchor a chapter entry; (2) the espeak-ng preflight was rewritten from
+always-assume-broken to probe-first (it actually exercises `misaki`'s G2P
+before deciding whether to symlink a Homebrew build), since the bundled
+data path was empirically confirmed to work on some installs and not
+others with byte-identical files; (3) `strip_chapter_markers()`'s regex
+was mashing back-to-back marker titles together with no separator
+(`\s` matches `\n`, so the greedy edges ate the blank line between
+adjacent markers) — narrowed to `[ \t]*` on the outer edges. See
+`docs/sessionlogs/` for the full session record, including the real-render
+verification.
 
 ## Future Improvements
 

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 metadata:
   author: eins78
   repo: https://github.com/eins78/agent-skills
-  version: "1.1.0"
+  version: "2.0.0"
 ---
 
 # text-to-speech
@@ -21,10 +21,23 @@ Converts a text document to an MP3 audio file via a local TTS pipeline. The skil
 
 > **Does NOT install any TTS backend.** See [Backend Dependencies](#backend-dependencies).
 
+> **v2.0.0 breaking change:** the narrative rewrite (L1) no longer runs
+> automatically inside `synth-audio.sh`. If you're a driving Claude Code
+> agent, dispatch a rewrite subagent first — see [L1 Narrative Rewrite](#l1-narrative-rewrite--dispatch-a-subagent-do-this-first)
+> below — this is the normal way to use the skill now, not an edge case.
+> A bare `synth-audio.sh input.md output.mp3` with no existing
+> `narrative.txt` now fails loudly instead of silently shelling out to
+> `claude --print` (that nested call could inherit your session's output
+> style/CLAUDE.md and leak meta-commentary into the audio — see
+> [L1 Narrative Rewrite](#l1-narrative-rewrite--dispatch-a-subagent-do-this-first)
+> for why). For headless/standalone use, pass `--allow-inline-llm-rewrite`.
+
 ## Quick Start
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/synth-audio.sh input.md output.mp3
+${CLAUDE_SKILL_DIR}/scripts/synth-audio.sh input.md output.mp3 --skip-layer 1
+# ^ requires <output.mp3>.workdir/narrative.txt to already exist — see
+#   "L1 Narrative Rewrite" below for how to produce it (subagent dispatch)
 ```
 
 Copy and configure backend settings (optional):
@@ -54,6 +67,52 @@ See `${CLAUDE_SKILL_DIR}/templates/synth-backend.yaml.example` for annotated def
 
 When `--backend kokoro` (default), the pipeline runs four layers:
 **L1** narrative rewrite (LLM) → **L2** normalization → **L3** prosody prep → **render**
+
+### L1 Narrative Rewrite — dispatch a subagent (do this first)
+
+**If you are the driving Claude Code agent, do this before calling `synth-audio.sh`.**
+Do NOT let `synth-audio.sh`/`pipeline.py` shell out to `claude --print` for you —
+a nested `claude --print` launched from inside your own session inherits your
+active output style, project `CLAUDE.md`, and any other session framing, and
+can return meta-commentary instead of a rewrite (observed failure: a literal
+`★ Insight` block rendered into the audio). Dispatching a subagent via the
+`Agent`/Task tool gives a genuinely isolated context instead.
+
+1. Determine `<workdir>` = `<output.mp3 path with .mp3 stripped>.workdir` and
+   `mkdir -p` it (this matches the directory the backend itself creates).
+2. Dispatch **one subagent** (general-purpose) with a self-contained prompt:
+   - Read `${CLAUDE_SKILL_DIR}/scripts/backends/prompts/narrative-chapter-focused.md`
+     and follow it exactly as the rewrite rules.
+   - Read the input document.
+   - Output ONLY the rewritten prose with `[[CHAPTER: ...]]` markers — no
+     preamble, no explanation, no markdown fences, no commentary about the
+     task itself.
+   - Instruct it to **write the result directly to `<workdir>/narrative.txt`**
+     (via Write) and return only a short status line — don't have it return
+     multi-thousand-word prose through the tool result.
+   - For documents >5000 words, either let the subagent chunk internally by
+     H2, or dispatch one subagent per H2 section in parallel and concatenate
+     — this replaces `chunk_and_rewrite.py`'s own `claude --print` calls when
+     you're running inside a session.
+3. Run:
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/synth-audio.sh input.md output.mp3 --skip-layer 1 [other flags]
+   ```
+   `pipeline.py` validates `narrative.txt` (chapter markers present, word
+   count plausible vs. the source, no known contamination patterns) before
+   continuing to L2/L3/render — if validation fails it exits loudly rather
+   than rendering audio from a bad narrative. Re-dispatch the subagent and
+   retry.
+
+**Standalone / headless (no driving agent present):** pass
+`--allow-inline-llm-rewrite` to `synth-audio.sh`. This falls back to an
+isolated inline `claude --print --safe-mode` call inside the pipeline
+(`--safe-mode` disables CLAUDE.md auto-discovery, output styles, hooks,
+plugins, and custom agents/commands). It's a weaker guarantee than subagent
+dispatch — there's no independent process boundary confirming isolation
+beyond the flag itself — so `validate_narrative()` still runs as the
+backstop either way. Prefer subagent dispatch whenever a driving agent is
+available.
 
 ### Voice and Speed
 
@@ -115,6 +174,24 @@ ${CLAUDE_SKILL_DIR}/scripts/synth-audio.sh input.md output.mp3 --verify
 
 After render, transcribes the MP3 with Whisper and reports IPA regressions, missing ordinal patterns, and unexpected artefacts. Requires `mlx-whisper` (Apple Silicon; `uv pip install mlx-whisper`).
 
+## ID3 Lyrics (USLT) — narrative debug artefact
+
+The backend embeds the final `narrative.txt` (chapter markers stripped to
+plain title lines) into the rendered MP3's ID3 `USLT` (lyrics) frame by
+default — the spoken text travels inside the file, so you can compare it
+against the source without a separate artefact. Pass `--no-lyrics` to
+`synth-audio.sh` to skip it. Read it back with:
+
+```bash
+uv run --with mutagen --no-project python -c "
+from mutagen.id3 import ID3
+id3 = ID3('output.mp3')
+for k, f in id3.items():
+    if k.startswith('USLT'):
+        print(str(f.text))
+"
+```
+
 ## Backend Dependencies
 
 The skill does NOT install or configure backend software. Caller must provide:
@@ -122,7 +199,23 @@ The skill does NOT install or configure backend software. Caller must provide:
 - **Kokoro-82M:** `uv pip install kokoro` (hexgrad/kokoro)
 - **Python 3.11+** with `uv`
 - **ffmpeg:** `brew install ffmpeg`
-- **mutagen:** `uv pip install mutagen` (for ID3 chapter injection)
+- **espeak-ng:** `brew install espeak-ng` — **hard dependency**, not optional.
+  Kokoro's `misaki` G2P depends on `espeakng_loader`, whose bundled
+  `libespeak-ng.dylib` has a compiled-in CI build data path
+  (`/Users/runner/work/espeakng-loader/...`) that doesn't exist on user
+  machines and hard-aborts before Python can flush stdout. `kokoro.sh` runs
+  an idempotent preflight (macOS) that symlinks the loader's dylibs to your
+  Homebrew `espeak-ng` build automatically — but the brew package itself
+  must be installed. If TTS aborts with an `espeak-ng-data` path error,
+  this is why.
+- **`VIRTUAL_ENV` must be set** in the calling environment. `misaki`
+  auto-installs the `en-core-web-sm` spaCy model via `uv pip install` on
+  first use; under `uv run --no-project` with no active `VIRTUAL_ENV` this
+  fails with an unhelpful "No virtual environment found" (exit 2, no
+  traceback). `kokoro.sh` checks this upfront and fails loudly with the fix
+  (`export VIRTUAL_ENV=/path/to/your/venv`) rather than letting the render
+  fail deep inside misaki.
+- **mutagen:** `uv pip install mutagen` (for ID3 chapter + lyrics injection)
 - **mlx-whisper** (optional, for `--verify`): `uv pip install mlx-whisper`
 
 ## Known Kokoro Limitations

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -199,15 +199,18 @@ The skill does NOT install or configure backend software. Caller must provide:
 - **Kokoro-82M:** `uv pip install kokoro` (hexgrad/kokoro)
 - **Python 3.11+** with `uv`
 - **ffmpeg:** `brew install ffmpeg`
-- **espeak-ng:** `brew install espeak-ng` — **hard dependency**, not optional.
-  Kokoro's `misaki` G2P depends on `espeakng_loader`, whose bundled
-  `libespeak-ng.dylib` has a compiled-in CI build data path
-  (`/Users/runner/work/espeakng-loader/...`) that doesn't exist on user
-  machines and hard-aborts before Python can flush stdout. `kokoro.sh` runs
-  an idempotent preflight (macOS) that symlinks the loader's dylibs to your
-  Homebrew `espeak-ng` build automatically — but the brew package itself
-  must be installed. If TTS aborts with an `espeak-ng-data` path error,
-  this is why.
+- **espeak-ng:** conditional dependency — `brew install espeak-ng` as a
+  fallback. Kokoro's `misaki` G2P depends on `espeakng_loader`, whose
+  bundled `libespeak-ng.dylib` data-path resolution is not reliably correct
+  on every install (observed: byte-identical dylib+data works fine from a
+  normally-located venv, hard-aborts before Python can flush stdout from a
+  venv nested under a long path — it's install-dependent, not universal).
+  `kokoro.sh` runs a probe-first preflight (macOS): it actually exercises
+  `misaki`'s G2P once, and only if that fails does it symlink the loader's
+  dylibs to a Homebrew `espeak-ng` build — silent and a no-op when the
+  bundled path already works. If TTS aborts with an `espeak-ng-data` path
+  error and you don't have `espeak-ng` installed via Homebrew, that's the
+  fallback you need.
 - **`VIRTUAL_ENV` must be set** in the calling environment. `misaki`
   auto-installs the `en-core-web-sm` spaCy model via `uv pip install` on
   first use; under `uv run --no-project` with no active `VIRTUAL_ENV` this

--- a/skills/text-to-speech/scripts/backends/kokoro.sh
+++ b/skills/text-to-speech/scripts/backends/kokoro.sh
@@ -8,9 +8,11 @@
 #   - Python 3.11+ with uv
 #   - kokoro package: uv pip install kokoro
 #   - ffmpeg: brew install ffmpeg
-#   - espeak-ng: brew install espeak-ng (hard dep of misaki's G2P — the
-#     bundled espeakng_loader dylib has a broken compiled-in data path;
-#     see the espeak-ng preflight below)
+#   - espeak-ng: brew install espeak-ng — misaki's G2P depends on
+#     espeakng_loader's bundled dylib, whose data-path resolution is not
+#     reliably correct on every install (see the probe-first preflight
+#     below); Homebrew espeak-ng is the fallback when the bundled path
+#     doesn't work, not a hard requirement on machines where it does
 #   - mutagen: uv pip install mutagen
 #   - mlx-whisper (optional, for --verify): uv pip install mlx-whisper
 #   - VIRTUAL_ENV must be set (see precondition below) — misaki auto-installs
@@ -95,34 +97,48 @@ uv run --no-project python "${LIB_DIR}/pipeline.py" \
 
 # ---------- F3: espeak-ng data-path preflight (macOS) ----------
 # The espeakng_loader package (a misaki/Kokoro dependency) ships a
-# libespeak-ng.dylib with a compiled-in CI build path for espeak-ng-data
-# (e.g. /Users/runner/work/espeakng-loader/...) that doesn't exist on user
-# machines — misaki hard-aborts before Python can flush stdout. Symlinking
-# the loader's dylibs to a system espeak-ng build (brew) fixes it, since
-# that build's compiled-in default path is valid. Idempotent (safe to
-# re-run every invocation) and self-heals after `brew reinstall espeak-ng`
-# changes the target. Derives the brew prefix rather than hardcoding
-# /opt/homebrew, since Intel Macs use /usr/local.
+# libespeak-ng.dylib whose data-path resolution is not always reliable —
+# it can hard-abort before Python can flush stdout on some installs (a
+# CI-build path baked in, or otherwise). But it is NOT reliably broken:
+# the same dylib works fine on some machines/installs and fails on others
+# (observed on this project: identical espeakng_loader build, byte-identical
+# dylib+data — works from a normally-located venv, fails from a venv nested
+# under a long path). Don't assume; probe. Run the actual runtime code path
+# (misaki.espeak's import-time init + a real phonemize call) in a
+# subprocess — if it fails/aborts, only THEN fix it by symlinking the
+# loader's dylibs to a system espeak-ng build (brew), whose data path is
+# independently valid. If it already works, do nothing and stay silent —
+# no spurious warnings on a machine where nothing is wrong.
 if [[ "$(uname)" == "Darwin" ]]; then
-    LOADER_DIR="$(uv run --no-project python -c \
-        'import espeakng_loader, os; print(os.path.dirname(espeakng_loader.__file__))' \
-        2>/dev/null || true)"
-    if [[ -n "$LOADER_DIR" && -d "$LOADER_DIR" ]]; then
-        BREW_ESPEAK_PREFIX="$(brew --prefix espeak-ng 2>/dev/null || true)"
-        BREW_ESPEAK_LIB="${BREW_ESPEAK_PREFIX}/lib/libespeak-ng.dylib"
-        if [[ -n "$BREW_ESPEAK_PREFIX" && -f "$BREW_ESPEAK_LIB" ]]; then
-            for dylib in libespeak-ng.dylib libespeak-ng.1.dylib libespeak-ng.1.52.0.dylib; do
-                target="${LOADER_DIR}/${dylib}"
-                # only touch it if it's already a symlink (or absent) — never
-                # clobber a real file placed there on purpose
-                if [[ ! -e "$target" || -L "$target" ]]; then
-                    ln -sf "$BREW_ESPEAK_LIB" "$target"
-                fi
-            done
-            echo "[kokoro] espeak-ng: linked bundled loader dylibs to $BREW_ESPEAK_LIB"
-        else
-            echo "[kokoro] warning: espeak-ng not found via Homebrew — if TTS aborts" >&2
-            echo "[kokoro]   with an espeak-ng-data path error, run: brew install espeak-ng" >&2
+    if uv run --no-project python -c "
+import types
+from misaki.espeak import EspeakFallback
+g2p = EspeakFallback(british=False)
+ps, _ = g2p(types.SimpleNamespace(text='hello'))
+assert ps
+" >/dev/null 2>&1; then
+        : # bundled espeak-ng data path already works here — nothing to do
+    else
+        LOADER_DIR="$(uv run --no-project python -c \
+            'import espeakng_loader, os; print(os.path.dirname(espeakng_loader.__file__))' \
+            2>/dev/null || true)"
+        if [[ -n "$LOADER_DIR" && -d "$LOADER_DIR" ]]; then
+            BREW_ESPEAK_PREFIX="$(brew --prefix espeak-ng 2>/dev/null || true)"
+            BREW_ESPEAK_LIB="${BREW_ESPEAK_PREFIX}/lib/libespeak-ng.dylib"
+            if [[ -n "$BREW_ESPEAK_PREFIX" && -f "$BREW_ESPEAK_LIB" ]]; then
+                for dylib in libespeak-ng.dylib libespeak-ng.1.dylib libespeak-ng.1.52.0.dylib; do
+                    target="${LOADER_DIR}/${dylib}"
+                    # only touch it if it's already a symlink (or absent) —
+                    # never clobber a real file placed there on purpose
+                    if [[ ! -e "$target" || -L "$target" ]]; then
+                        ln -sf "$BREW_ESPEAK_LIB" "$target"
+                    fi
+                done
+                echo "[kokoro] espeak-ng: bundled data path failed its probe — linked loader dylibs to $BREW_ESPEAK_LIB"
+            else
+                echo "[kokoro] error: bundled espeak-ng data path failed its probe, and no" >&2
+                echo "[kokoro]   Homebrew espeak-ng was found to fall back to — run: brew install espeak-ng" >&2
+            fi
         fi
     fi
 fi

--- a/skills/text-to-speech/scripts/backends/kokoro.sh
+++ b/skills/text-to-speech/scripts/backends/kokoro.sh
@@ -8,18 +8,45 @@
 #   - Python 3.11+ with uv
 #   - kokoro package: uv pip install kokoro
 #   - ffmpeg: brew install ffmpeg
+#   - espeak-ng: brew install espeak-ng (hard dep of misaki's G2P — the
+#     bundled espeakng_loader dylib has a broken compiled-in data path;
+#     see the espeak-ng preflight below)
 #   - mutagen: uv pip install mutagen
 #   - mlx-whisper (optional, for --verify): uv pip install mlx-whisper
+#   - VIRTUAL_ENV must be set (see precondition below) — misaki auto-installs
+#     the en-core-web-sm spaCy model via `uv pip install` on first use, which
+#     needs an active venv to install into
 
 set -euo pipefail
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)"
+
+# ---------- F4: VIRTUAL_ENV precondition ----------
+# misaki (Kokoro's G2P dependency) auto-installs the en-core-web-sm spaCy
+# model via `uv pip install` on first use. Under `uv run --no-project` with
+# no active VIRTUAL_ENV, that install fails with "No virtual environment
+# found" (exit 2, no traceback) — a confusing failure far from its real
+# cause. A loud precondition here beats silently inferring a venv path:
+# `uv run --no-project python` can resolve a uv-managed interpreter that
+# isn't a pip-installable venv, so inference risks setting VIRTUAL_ENV
+# somewhere `uv pip install` still can't use.
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+    echo "error: VIRTUAL_ENV is not set." >&2
+    echo "  misaki (Kokoro's G2P dependency) auto-installs the en-core-web-sm" >&2
+    echo "  spaCy model via 'uv pip install' on first use, which requires an" >&2
+    echo "  active virtual environment to install into. Fix:" >&2
+    echo "    export VIRTUAL_ENV=/path/to/your/venv" >&2
+    echo "  then re-run synth-audio.sh." >&2
+    exit 1
+fi
 
 # ---------- defaults ----------
 VOICE="am_puck"
 SPEED="0.92"
 SKIP_LAYER=0
 VERIFY=0
+ALLOW_INLINE_LLM_REWRITE=0
+NO_LYRICS=0
 INPUT_FILE=""
 OUTPUT_FILE=""
 
@@ -33,6 +60,8 @@ while [[ $# -gt 0 ]]; do
         --skill-dir)  shift 2 ;;  # accepted but unused — backend computes own path
         --skip-layer) SKIP_LAYER="$2";  shift 2 ;;
         --verify)     VERIFY=1;         shift   ;;
+        --allow-inline-llm-rewrite) ALLOW_INLINE_LLM_REWRITE=1; shift ;;
+        --no-lyrics)  NO_LYRICS=1;      shift ;;
         *) echo "error: unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -54,20 +83,60 @@ echo "[kokoro] voice:    $VOICE  speed: $SPEED  skip-layer: $SKIP_LAYER"
 
 # ---------- L1→L3c: pipeline.py ----------
 echo "[kokoro] running pipeline (L1→L3c)..."
+INLINE_LLM_FLAG=""
+[[ "$ALLOW_INLINE_LLM_REWRITE" == "1" ]] && INLINE_LLM_FLAG="--allow-inline-llm-rewrite"
 uv run --no-project python "${LIB_DIR}/pipeline.py" \
     "$INPUT_ABS" \
     "$WORK_DIR" \
     --skip-layer "$SKIP_LAYER" \
-    --llm-model "claude-sonnet-4-6" \
-    --prompt "${LIB_DIR}/../prompts/narrative-chapter-focused.md"
+    --llm-model "claude-sonnet-5" \
+    --prompt "${LIB_DIR}/../prompts/narrative-chapter-focused.md" \
+    ${INLINE_LLM_FLAG}
+
+# ---------- F3: espeak-ng data-path preflight (macOS) ----------
+# The espeakng_loader package (a misaki/Kokoro dependency) ships a
+# libespeak-ng.dylib with a compiled-in CI build path for espeak-ng-data
+# (e.g. /Users/runner/work/espeakng-loader/...) that doesn't exist on user
+# machines — misaki hard-aborts before Python can flush stdout. Symlinking
+# the loader's dylibs to a system espeak-ng build (brew) fixes it, since
+# that build's compiled-in default path is valid. Idempotent (safe to
+# re-run every invocation) and self-heals after `brew reinstall espeak-ng`
+# changes the target. Derives the brew prefix rather than hardcoding
+# /opt/homebrew, since Intel Macs use /usr/local.
+if [[ "$(uname)" == "Darwin" ]]; then
+    LOADER_DIR="$(uv run --no-project python -c \
+        'import espeakng_loader, os; print(os.path.dirname(espeakng_loader.__file__))' \
+        2>/dev/null || true)"
+    if [[ -n "$LOADER_DIR" && -d "$LOADER_DIR" ]]; then
+        BREW_ESPEAK_PREFIX="$(brew --prefix espeak-ng 2>/dev/null || true)"
+        BREW_ESPEAK_LIB="${BREW_ESPEAK_PREFIX}/lib/libespeak-ng.dylib"
+        if [[ -n "$BREW_ESPEAK_PREFIX" && -f "$BREW_ESPEAK_LIB" ]]; then
+            for dylib in libespeak-ng.dylib libespeak-ng.1.dylib libespeak-ng.1.52.0.dylib; do
+                target="${LOADER_DIR}/${dylib}"
+                # only touch it if it's already a symlink (or absent) — never
+                # clobber a real file placed there on purpose
+                if [[ ! -e "$target" || -L "$target" ]]; then
+                    ln -sf "$BREW_ESPEAK_LIB" "$target"
+                fi
+            done
+            echo "[kokoro] espeak-ng: linked bundled loader dylibs to $BREW_ESPEAK_LIB"
+        else
+            echo "[kokoro] warning: espeak-ng not found via Homebrew — if TTS aborts" >&2
+            echo "[kokoro]   with an espeak-ng-data path error, run: brew install espeak-ng" >&2
+        fi
+    fi
+fi
 
 # ---------- render: kokoro_round5.py ----------
 echo "[kokoro] rendering audio..."
 SLUG="$(basename "${OUTPUT_FILE%.mp3}")"
+NO_LYRICS_FLAG=""
+[[ "$NO_LYRICS" == "1" ]] && NO_LYRICS_FLAG="--no-lyrics"
 uv run --no-project python "${LIB_DIR}/kokoro_round5.py" \
     "$WORK_DIR" \
     --voice "$VOICE" \
     --speed "$SPEED" \
+    ${NO_LYRICS_FLAG} \
     "${SLUG}:${WORK_DIR}"
 
 # kokoro_round5.py writes to <out_dir>/kokoro-<voice>-<slug>.mp3

--- a/skills/text-to-speech/scripts/backends/lib/chunk_and_rewrite.py
+++ b/skills/text-to-speech/scripts/backends/lib/chunk_and_rewrite.py
@@ -4,13 +4,23 @@
 Workaround for long-document LLM calls that stall/throttle on >5k-word
 inputs. Each H2 chunk is ~500-1500 words — LLM calls complete in ~30-60s.
 
+Standalone/headless CLI utility — NOT wired into kokoro.sh/synth-audio.sh.
+When running inside an active Claude Code session, prefer having the
+driving agent dispatch one rewrite subagent per H2 section in parallel
+and concatenate the results into narrative.txt itself (see SKILL.md) —
+that gets you the same chunking benefit with genuine context isolation.
+Use this script only for headless/CI runs with no driving agent present.
+
 Usage:
     chunk_and_rewrite.py <markdown> <narrative_out> [--prompt PATH] \\
         [--llm-model MODEL]
 
 Output narrative.txt is the concatenation of chunk outputs, blank-line
 separated. Each chunk naturally produces a [[CHAPTER]] marker for its
-H2 under the chapter-focused prompt.
+H2 under the chapter-focused prompt. Its output should still be passed
+through pipeline.py's validate_narrative() before rendering — run
+pipeline.py with --skip-layer 1 afterward rather than feeding kokoro.txt
+straight to the renderer.
 """
 
 from __future__ import annotations
@@ -53,6 +63,14 @@ def chunk_by_h2(md: str) -> list[str]:
 
 
 def rewrite_chunk(chunk: str, prompt_text: str, model: str, idx: int, total: int) -> str:
+    # NOTE: like pipeline.py's inline fallback, this is a standalone/manual
+    # CLI utility (not wired into kokoro.sh's default L1 path — see
+    # SKILL.md for the recommended subagent-dispatch workflow instead).
+    # --safe-mode disables CLAUDE.md auto-discovery, output styles, hooks,
+    # plugins, and custom agents/commands, so a `claude --print` run from
+    # inside an active Claude Code session can't leak session
+    # meta-commentary (e.g. an output-style "★ Insight" block) into the
+    # rewrite — see pipeline.py's run_layer1() for the same treatment.
     user_msg = (
         "Rewrite the following dossier section into spoken prose per the "
         "system prompt rules. Output ONLY the rewritten prose with chapter "
@@ -65,6 +83,7 @@ def rewrite_chunk(chunk: str, prompt_text: str, model: str, idx: int, total: int
         [
             "claude", "--print",
             "--model", model,
+            "--safe-mode",
             "--system-prompt", prompt_text,
             user_msg,
         ],
@@ -98,7 +117,7 @@ def main() -> int:
     ap.add_argument("markdown")
     ap.add_argument("narrative_out")
     ap.add_argument("--prompt", default=str(DEFAULT_PROMPT))
-    ap.add_argument("--llm-model", default="claude-sonnet-4-6")
+    ap.add_argument("--llm-model", default="claude-sonnet-5")
     args = ap.parse_args()
 
     md = Path(args.markdown).read_text()

--- a/skills/text-to-speech/scripts/backends/lib/inject_chapters.py
+++ b/skills/text-to-speech/scripts/backends/lib/inject_chapters.py
@@ -42,7 +42,15 @@ from mutagen.id3 import ID3NoHeaderError
 from mutagen.mp3 import MP3
 
 
-_CHAPTER_MARKER_RE = re.compile(r"^\s*\[\[CHAPTER:\s*(.+?)\s*\]\]\s*$", re.MULTILINE)
+# NOTE: unlike pipeline.py/kokoro_round5.py's CHAPTER_MARKER_RE (which only
+# needs match.start()/group(1) for detection, so leading/trailing \s greed
+# is harmless), this copy is used for in-place substitution in
+# strip_chapter_markers(). \s matches \n, so a plain `\s*$`/`^\s*` here
+# would eat the blank line separating two back-to-back markers (e.g. the
+# H1-title marker immediately followed by the first H2 marker) and mash
+# adjacent titles together with no separator at all. [ \t]* keeps the
+# strip scoped to horizontal whitespace on the marker's own line.
+_CHAPTER_MARKER_RE = re.compile(r"^[ \t]*\[\[CHAPTER:\s*(.+?)\s*\]\][ \t]*$", re.MULTILINE)
 
 
 def strip_chapter_markers(narrative: str) -> str:
@@ -180,12 +188,33 @@ def self_test() -> int:
             {"start_ms": 7000, "title": "Conclusion"},
         ]
         (mp3.with_suffix(mp3.suffix + ".chapters.json")).write_text(json.dumps(chapters))
+        # Back-to-back markers with no body between them (e.g. the
+        # H1-title marker immediately followed by the first H2 marker,
+        # per narrative-chapter-focused.md's convention) is the real
+        # pattern that broke a `\s`-greedy version of this regex in
+        # production — assert against a hand-written expected string,
+        # not just round-trip consistency with strip_chapter_markers'
+        # own output, or a regression here won't be caught.
         narrative = (
+            "[[CHAPTER: Doc Title]]\n\n"
             "[[CHAPTER: Intro]]\n\nWelcome.\n\n"
             "[[CHAPTER: Middle bit]]\n\nThe middle.\n\n"
             "[[CHAPTER: Conclusion]]\n\nThe end."
         )
         lyrics = strip_chapter_markers(narrative)
+        expected_lyrics = (
+            "Doc Title\n\n"
+            "Intro\n\nWelcome.\n\n"
+            "Middle bit\n\nThe middle.\n\n"
+            "Conclusion\n\nThe end."
+        )
+        if lyrics != expected_lyrics:
+            print(
+                f"FAIL: strip_chapter_markers produced {lyrics!r}, "
+                f"expected {expected_lyrics!r}",
+                file=sys.stderr,
+            )
+            return 1
         inject(mp3, chapters, lyrics=lyrics)
         got = read_back(mp3)
         print(f"[self-test] wrote + read back {len(got)} chapters:")

--- a/skills/text-to-speech/scripts/backends/lib/inject_chapters.py
+++ b/skills/text-to-speech/scripts/backends/lib/inject_chapters.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Inject ID3v2 CHAP + CTOC chapter frames into an MP3.
+"""Inject ID3v2 CHAP + CTOC chapter frames (and optionally a USLT lyrics
+frame) into an MP3.
 
 Reads <mp3>.chapters.json (sibling file), writes ID3 chapter metadata
 so podcast clients (Overcast, Apple Podcasts) can show skippable chapters.
 
 Usage:
-    inject_chapters.py <mp3_path> [--chapters <path>]
+    inject_chapters.py <mp3_path> [--chapters <path>] [--lyrics <path>] [--no-lyrics]
 
 chapters.json schema:
     [
@@ -18,6 +19,13 @@ Chapters must be strictly increasing by start_ms. End time of chapter N
 is set to start time of chapter N+1; the last chapter ends at the MP3's
 total duration (read via mutagen).
 
+Lyrics (USLT): if --lyrics points at a narrative.txt-style file (or is
+omitted and <mp3>.workdir/narrative.txt-equivalent is passed directly),
+its [[CHAPTER: ...]] markers are stripped to plain readable title lines
+and the result is embedded as an ID3 USLT frame — the full spoken text
+travels inside the MP3 for debugging/comparison against the source,
+without a separate artefact. Pass --no-lyrics to skip this.
+
 Self-test: run with `--self-test` to write + read-back a synthetic MP3.
 """
 
@@ -25,12 +33,23 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
-from mutagen.id3 import ID3, CHAP, CTOC, CTOCFlags, TIT2, Encoding
+from mutagen.id3 import ID3, CHAP, CTOC, CTOCFlags, TIT2, USLT, Encoding
 from mutagen.id3 import ID3NoHeaderError
 from mutagen.mp3 import MP3
+
+
+_CHAPTER_MARKER_RE = re.compile(r"^\s*\[\[CHAPTER:\s*(.+?)\s*\]\]\s*$", re.MULTILINE)
+
+
+def strip_chapter_markers(narrative: str) -> str:
+    """Convert `[[CHAPTER: Title]]` marker lines into plain readable title
+    lines, for embedding narrative.txt as ID3 lyrics — keeps chapter
+    structure visible in a lyrics viewer without the marker syntax."""
+    return _CHAPTER_MARKER_RE.sub(lambda m: m.group(1), narrative)
 
 
 def load_chapters(chapters_path: Path) -> list[dict]:
@@ -52,8 +71,9 @@ def load_chapters(chapters_path: Path) -> list[dict]:
     return data
 
 
-def inject(mp3_path: Path, chapters: list[dict]) -> None:
-    """Write CHAP + CTOC frames to the MP3 in place."""
+def inject(mp3_path: Path, chapters: list[dict], lyrics: str | None = None) -> None:
+    """Write CHAP + CTOC frames (and optionally a USLT lyrics frame) to the
+    MP3 in place."""
     mp3 = MP3(str(mp3_path))
     total_ms = int(mp3.info.length * 1000)
 
@@ -62,10 +82,10 @@ def inject(mp3_path: Path, chapters: list[dict]) -> None:
     except ID3NoHeaderError:
         id3 = ID3()
 
-    # Clear existing CHAP / CTOC frames — we don't want duplicates when
-    # called idempotently. mutagen lets us drop by key.
+    # Clear existing CHAP / CTOC / USLT frames — we don't want duplicates
+    # when called idempotently. mutagen lets us drop by key.
     for key in list(id3.keys()):
-        if key.startswith("CHAP:") or key.startswith("CTOC:"):
+        if key.startswith("CHAP:") or key.startswith("CTOC:") or key.startswith("USLT:"):
             del id3[key]
 
     element_ids: list[str] = []
@@ -96,6 +116,16 @@ def inject(mp3_path: Path, chapters: list[dict]) -> None:
         )
     )
 
+    if lyrics is not None:
+        id3.add(
+            USLT(
+                encoding=Encoding.UTF8,
+                lang="eng",
+                desc="",
+                text=lyrics,
+            )
+        )
+
     id3.save(str(mp3_path), v2_version=3)
 
 
@@ -114,6 +144,15 @@ def read_back(mp3_path: Path) -> list[tuple[int, int, str]]:
         out.append((frame.start_time, frame.end_time, title))
     out.sort(key=lambda t: t[0])
     return out
+
+
+def read_back_lyrics(mp3_path: Path) -> str | None:
+    """Return the USLT frame's text, or None if no lyrics frame exists."""
+    id3 = ID3(str(mp3_path))
+    for key, frame in id3.items():
+        if key.startswith("USLT:"):
+            return str(frame.text)
+    return None
 
 
 def self_test() -> int:
@@ -141,7 +180,13 @@ def self_test() -> int:
             {"start_ms": 7000, "title": "Conclusion"},
         ]
         (mp3.with_suffix(mp3.suffix + ".chapters.json")).write_text(json.dumps(chapters))
-        inject(mp3, chapters)
+        narrative = (
+            "[[CHAPTER: Intro]]\n\nWelcome.\n\n"
+            "[[CHAPTER: Middle bit]]\n\nThe middle.\n\n"
+            "[[CHAPTER: Conclusion]]\n\nThe end."
+        )
+        lyrics = strip_chapter_markers(narrative)
+        inject(mp3, chapters, lyrics=lyrics)
         got = read_back(mp3)
         print(f"[self-test] wrote + read back {len(got)} chapters:")
         for start_ms, end_ms, title in got:
@@ -151,11 +196,25 @@ def self_test() -> int:
         if expected_titles != got_titles:
             print(f"FAIL: titles mismatch: {expected_titles!r} vs {got_titles!r}", file=sys.stderr)
             return 1
-        # Idempotency check: inject twice, count frames.
-        inject(mp3, chapters)
+
+        got_lyrics = read_back_lyrics(mp3)
+        print(f"[self-test] lyrics frame: {got_lyrics!r}")
+        if got_lyrics != lyrics:
+            print(f"FAIL: lyrics mismatch: {lyrics!r} vs {got_lyrics!r}", file=sys.stderr)
+            return 1
+        if "[[CHAPTER:" in (got_lyrics or ""):
+            print("FAIL: lyrics still contain raw [[CHAPTER: ...]] marker syntax", file=sys.stderr)
+            return 1
+
+        # Idempotency check: inject twice, count frames (chapters + lyrics).
+        inject(mp3, chapters, lyrics=lyrics)
         got2 = read_back(mp3)
         if len(got2) != len(chapters):
             print(f"FAIL: idempotency broken — got {len(got2)} frames after 2nd inject", file=sys.stderr)
+            return 1
+        got_lyrics2 = read_back_lyrics(mp3)
+        if got_lyrics2 != lyrics:
+            print(f"FAIL: lyrics idempotency broken after 2nd inject: {got_lyrics2!r}", file=sys.stderr)
             return 1
         print("[self-test] OK")
         return 0
@@ -165,6 +224,16 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("mp3", nargs="?")
     ap.add_argument("--chapters", help="path to chapters.json (default: <mp3>.chapters.json)")
+    ap.add_argument(
+        "--lyrics",
+        help="path to narrative text for the ID3 USLT lyrics frame "
+        "(default: narrative.txt alongside the mp3, if present)",
+    )
+    ap.add_argument(
+        "--no-lyrics",
+        action="store_true",
+        help="skip embedding the USLT lyrics frame even if narrative.txt is found",
+    )
     ap.add_argument("--self-test", action="store_true")
     args = ap.parse_args()
 
@@ -186,10 +255,22 @@ def main() -> int:
         print(f"error: chapters.json not found: {chapters_path}", file=sys.stderr)
         return 1
 
+    lyrics: str | None = None
+    if not args.no_lyrics:
+        lyrics_path = Path(args.lyrics) if args.lyrics else mp3_path.parent / "narrative.txt"
+        if lyrics_path.exists():
+            lyrics = strip_chapter_markers(lyrics_path.read_text())
+        elif args.lyrics:
+            print(f"error: lyrics file not found: {lyrics_path}", file=sys.stderr)
+            return 1
+
     chapters = load_chapters(chapters_path)
-    inject(mp3_path, chapters)
+    inject(mp3_path, chapters, lyrics=lyrics)
     got = read_back(mp3_path)
-    print(f"[chapters] wrote {len(got)} chapter frames to {mp3_path}")
+    print(
+        f"[chapters] wrote {len(got)} chapter frames to {mp3_path}"
+        + (" + lyrics (USLT)" if lyrics else "")
+    )
     for start_ms, end_ms, title in got:
         mm_ss = f"{start_ms // 60000:02d}:{(start_ms // 1000) % 60:02d}"
         print(f"  {mm_ss}  {title}")

--- a/skills/text-to-speech/scripts/backends/lib/kokoro_round5.py
+++ b/skills/text-to-speech/scripts/backends/lib/kokoro_round5.py
@@ -116,12 +116,20 @@ def synth_full(
     total_segments = 0
 
     for title, body in parts:
+        body = body.strip()
+        if not body:
+            # A part with no body contributes no audio, so it can't anchor
+            # a chapter start — e.g. the H1-title-only marker that
+            # immediately precedes the first H2 marker with no body of its
+            # own (per narrative-chapter-focused.md's "first marker = the
+            # dossier's H1 title" convention). Appending a chapter entry
+            # here would pin it at the same cumulative_samples position as
+            # the next real chapter, producing a zero-duration chapter that
+            # inject_chapters.py correctly rejects.
+            continue
         if title is not None:
             start_ms = int(cumulative_samples / SAMPLE_RATE * 1000)
             chapters_ms.append({"start_ms": start_ms, "title": title})
-        body = body.strip()
-        if not body:
-            continue
         for _, _, audio in pipeline(body, voice=voice, speed=speed):
             all_audio.append(audio)
             cumulative_samples += len(audio)

--- a/skills/text-to-speech/scripts/backends/lib/kokoro_round5.py
+++ b/skills/text-to-speech/scripts/backends/lib/kokoro_round5.py
@@ -43,6 +43,7 @@ from kokoro import KPipeline
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from inject_chapters import inject as inject_chapters  # noqa: E402
+from inject_chapters import strip_chapter_markers  # noqa: E402
 
 
 SAMPLE_RATE = 24000
@@ -103,6 +104,7 @@ def synth_full(
     wav_path: Path,
     mp3_path: Path,
     chapters_path: Path,
+    lyrics: str | None = None,
 ) -> dict:
     parts = split_on_chapters(kokoro_text, titles)
     print(f"[r5]   text split into {len(parts)} chunks with chapter markers")
@@ -136,7 +138,7 @@ def synth_full(
     rtf = elapsed / duration_s if duration_s else float("inf")
     chapters_path.write_text(json.dumps(chapters_ms, indent=2) + "\n")
     if chapters_ms:
-        inject_chapters(mp3_path, chapters_ms)
+        inject_chapters(mp3_path, chapters_ms, lyrics=lyrics)
 
     return {
         "voice": voice,
@@ -198,6 +200,12 @@ def main() -> int:
         "--stable-passage",
         action="store_true",
         help="each source arg is a raw kokoro.txt path (no chapter handling)",
+    )
+    ap.add_argument(
+        "--no-lyrics",
+        action="store_true",
+        help="skip embedding narrative.txt as an ID3 USLT lyrics frame "
+        "(default: embed it when present alongside the pipeline output)",
     )
     ap.add_argument(
         "sources",
@@ -265,9 +273,15 @@ def main() -> int:
                 text = kokoro_txt.read_text()
                 titles = [c["title"] for c in json.loads(chapters_stub.read_text())]
                 chapters_path = out_dir / f"{stem}.mp3.chapters.json"
+                lyrics: str | None = None
+                if not args.no_lyrics:
+                    narrative_path = src_path / "narrative.txt"
+                    if narrative_path.exists():
+                        lyrics = strip_chapter_markers(narrative_path.read_text())
                 print(f"[r5] voice={args.voice} speed={speed} slug={slug} input_words={len(text.split())} titles={len(titles)}")
                 stats = synth_full(
-                    pipeline, text, args.voice, speed, titles, wav_path, mp3_path, chapters_path
+                    pipeline, text, args.voice, speed, titles, wav_path, mp3_path, chapters_path,
+                    lyrics=lyrics,
                 )
 
             stats["slug"] = slug

--- a/skills/text-to-speech/scripts/backends/lib/pipeline.py
+++ b/skills/text-to-speech/scripts/backends/lib/pipeline.py
@@ -2,8 +2,25 @@
 """End-to-end text-preparation pipeline for TTS.
 
 Stages:
-  L1  narrative rewrite (LLM: claude --print)
+  L1  narrative rewrite (LLM)
       → narrative.txt (contains [[CHAPTER: ...]] markers)
+
+      By default this pipeline does NOT produce narrative.txt itself — it
+      expects the driving Claude Code agent to have dispatched an isolated
+      subagent (per SKILL.md) to write it, then to be re-invoked with
+      --skip-layer 1. This avoids a nested `claude --print` subprocess
+      inheriting the caller's active output style / CLAUDE.md, which can
+      leak meta-commentary into the rewrite instead of clean prose.
+
+      For standalone/headless runs with no driving agent present, pass
+      --allow-inline-llm-rewrite to fall back to an isolated (--safe-mode)
+      inline `claude --print` call.
+
+      Regardless of source, narrative.txt is passed through
+      validate_narrative() before use — this is the load-bearing backstop
+      against non-conforming L1 output (missing chapter markers, collapsed
+      word count, or known contamination patterns), since subagent
+      isolation is a behavioral guarantee, not something checked statically.
   L2  rule normalization (normalize.py)
       → normalized.txt
   L3  Kokoro-specific prep:
@@ -21,12 +38,17 @@ Usage:
     pipeline.py <markdown> <out_dir> [options]
 
 Options:
-    --skip-layer N          reuse existing <out_dir>/<name-from-layer-N>
-                            (1..3) — skip the indicated layer + earlier
-    --llm-model MODEL       Claude model (default: claude-sonnet-4-6)
-    --prompt PATH           narrative prompt (default: bundled narrative-chapter-focused.md)
-    --dict PATH             phoneme dict YAML (default: ./phoneme-dict.yaml in input dir)
-    --stress PATH           stress hints YAML (default: ./stress.yaml in input dir)
+    --skip-layer N              reuse existing <out_dir>/<name-from-layer-N>
+                                (1..3) — skip the indicated layer + earlier
+    --allow-inline-llm-rewrite  allow an isolated inline `claude --print`
+                                call for L1 when narrative.txt doesn't
+                                already exist (default: off — fail loudly
+                                instead; see L1 note above)
+    --llm-model MODEL           Claude model for the inline fallback and
+                                chunk_and_rewrite.py (default: claude-sonnet-5)
+    --prompt PATH                narrative prompt (default: bundled narrative-chapter-focused.md)
+    --dict PATH                  phoneme dict YAML (default: ./phoneme-dict.yaml in input dir)
+    --stress PATH                stress hints YAML (default: ./stress.yaml in input dir)
 """
 
 from __future__ import annotations
@@ -66,7 +88,15 @@ def parse_chapters(text: str) -> list[dict]:
     return chapters
 
 
-# ---------- Layer 1 — LLM narrative rewrite ----------
+# ---------- Layer 1 — LLM narrative rewrite (inline fallback only) ----------
+#
+# This is ONLY used when --allow-inline-llm-rewrite is passed — the default
+# path expects narrative.txt to already exist, written by a subagent the
+# driving Claude Code agent dispatched (see SKILL.md and the module
+# docstring). --safe-mode disables CLAUDE.md auto-discovery, output styles,
+# hooks, plugins, and custom agents/commands — the inheritance vectors that
+# caused a nested `claude --print` to leak session meta-commentary
+# (e.g. an explanatory-output-style "★ Insight" block) into the rewrite.
 
 def run_layer1(md_text: str, prompt_path: Path, model: str) -> str:
     user_msg = (
@@ -76,11 +106,12 @@ def run_layer1(md_text: str, prompt_path: Path, model: str) -> str:
         "---SOURCE---\n"
         f"{md_text}"
     )
-    print(f"[L1] invoking {model} via claude CLI (prompt={prompt_path.name})")
+    print(f"[L1] invoking {model} via claude CLI --safe-mode (prompt={prompt_path.name})")
     result = subprocess.run(
         [
             "claude", "--print",
             "--model", model,
+            "--safe-mode",
             "--system-prompt", prompt_path.read_text(),
             user_msg,
         ],
@@ -97,6 +128,80 @@ def run_layer1(md_text: str, prompt_path: Path, model: str) -> str:
         if first_nl > 0 and first_nl < 200:
             out = out[first_nl:].lstrip()
     return out + "\n"
+
+
+# ---------- Layer 1 validation — defensive check on narrative.txt ----------
+#
+# Applies uniformly regardless of narrative.txt's source (subagent-written,
+# human-written, or the inline fallback above). This is the load-bearing
+# backstop for Finding 2: subagent context isolation is a behavioral
+# guarantee we verified empirically but can't check statically, so this
+# function is what actually prevents garbage narrative from reaching L2/L3
+# and being rendered to audio.
+
+_HEADING_RE = re.compile(r"^#{1,2}\s+.+$", re.MULTILINE)
+_SKIP_HEADING_RE = re.compile(
+    r"^#{1,2}\s+(Sources|References|Appendix|Citations|Bibliography|Further Reading)\b",
+    re.IGNORECASE,
+)
+
+# Known contamination patterns from the observed failure (a nested
+# `claude --print` inheriting an active output style leaked a literal
+# "★ Insight" block into rendered audio). This denylist is inherently
+# incomplete — it targets the observed failure mode at near-zero cost. The
+# structural checks below (missing markers, collapsed word count) are the
+# general defense; don't rely on this list alone.
+_CONTAMINATION_MARKERS = (
+    "★",
+    "Insight ─",
+    "approve the plan",
+    "The plan is written",
+)
+
+
+def validate_narrative(narrative: str, source_md: str) -> None:
+    """Fail loudly (SystemExit) if narrative.txt doesn't look like a real
+    rewrite of source_md. Never render audio from a narrative that fails
+    this check."""
+    chapters = parse_chapters(narrative)
+
+    expected_headings = [
+        m for m in _HEADING_RE.finditer(source_md)
+        if not _SKIP_HEADING_RE.match(m.group(0))
+    ]
+    if expected_headings and not chapters:
+        raise SystemExit(
+            "narrative validation FAILED: source has "
+            f"{len(expected_headings)} heading(s) but narrative.txt has "
+            "zero [[CHAPTER: ...]] markers. This usually means the L1 "
+            "rewrite returned meta-commentary instead of prose (e.g. it "
+            "echoed an output style or explained the task) rather than "
+            "following the narrative-chapter-focused.md prompt. Re-dispatch "
+            "the L1 rewrite and re-run with --skip-layer 1."
+        )
+
+    source_words = len(source_md.split())
+    narrative_words = len(narrative.split())
+    if source_words > 0 and narrative_words / source_words < 0.2:
+        raise SystemExit(
+            "narrative validation FAILED: narrative.txt has "
+            f"{narrative_words} words vs {source_words} in the source "
+            f"({narrative_words / source_words:.0%}) — looks collapsed, not "
+            "a rewrite. Re-dispatch the L1 rewrite and re-run with "
+            "--skip-layer 1."
+        )
+
+    lowered = narrative.lower()
+    hits = [m for m in _CONTAMINATION_MARKERS if m.lower() in lowered]
+    if hits:
+        raise SystemExit(
+            "narrative validation FAILED: narrative.txt contains text that "
+            f"looks like leaked session/meta-commentary ({hits!r}) rather "
+            "than spoken prose — a known failure mode when an LLM rewrite "
+            "inherits an active output style. Re-dispatch the L1 rewrite "
+            "(this check is a denylist, not exhaustive — inspect the file "
+            "manually too)."
+        )
 
 
 # ---------- Layer 3a — phoneme dict ----------
@@ -233,6 +338,7 @@ def run(
     dict_path: Path | None = None,
     stress_path: Path | None = None,
     em_dash_mode: str = "period-dash",
+    allow_inline_llm_rewrite: bool = False,
 ) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     narrative_path = out_dir / "narrative.txt"
@@ -254,10 +360,24 @@ def run(
     if skip_layer >= 1 and narrative_path.exists():
         print(f"[pipeline] L1 skipped (reusing {narrative_path})")
         narrative = narrative_path.read_text()
-    else:
+    elif allow_inline_llm_rewrite:
         narrative = run_layer1(md_text, prompt_path, model)
         narrative_path.write_text(narrative)
         print(f"[pipeline] L1 wrote {narrative_path} ({len(narrative.split())} words)")
+    else:
+        raise SystemExit(
+            f"no narrative found at {narrative_path}, and inline LLM "
+            "rewrite is disabled by default. Either:\n"
+            "  1. Have the driving Claude Code agent dispatch a rewrite "
+            "subagent per SKILL.md, write narrative.txt, then re-run with "
+            "--skip-layer 1 (recommended — isolated context, avoids "
+            "inheriting an active output style/CLAUDE.md), or\n"
+            "  2. Pass --allow-inline-llm-rewrite for a standalone/headless "
+            "run with no driving agent present (uses `claude --print "
+            "--safe-mode` internally)."
+        )
+
+    validate_narrative(narrative, md_text)
 
     chapters_pre = parse_chapters(narrative)
     print(f"[pipeline] found {len(chapters_pre)} chapter markers")
@@ -322,7 +442,17 @@ def main() -> int:
     ap.add_argument("markdown")
     ap.add_argument("out_dir")
     ap.add_argument("--skip-layer", type=int, default=0)
-    ap.add_argument("--llm-model", default="claude-sonnet-4-6")
+    ap.add_argument(
+        "--allow-inline-llm-rewrite",
+        action="store_true",
+        help=(
+            "allow an isolated inline `claude --print --safe-mode` call for "
+            "L1 when narrative.txt doesn't already exist (default: off — "
+            "fail loudly and expect the driving agent to have dispatched a "
+            "rewrite subagent per SKILL.md)"
+        ),
+    )
+    ap.add_argument("--llm-model", default="claude-sonnet-5")
     ap.add_argument("--prompt", default=str(DEFAULT_PROMPT))
     ap.add_argument("--dict", default=None, help="phoneme dict YAML (default: ./phoneme-dict.yaml)")
     ap.add_argument("--stress", default=None, help="stress hints YAML (default: ./stress.yaml)")
@@ -341,6 +471,7 @@ def main() -> int:
         Path(args.prompt),
         dict_path=Path(args.dict) if args.dict else None,
         stress_path=Path(args.stress) if args.stress else None,
+        allow_inline_llm_rewrite=args.allow_inline_llm_rewrite,
         em_dash_mode=args.em_dash_mode,
     )
     return 0

--- a/skills/text-to-speech/scripts/synth-audio.sh
+++ b/skills/text-to-speech/scripts/synth-audio.sh
@@ -10,6 +10,14 @@
 #   --speed     backend-specific speed    (kokoro default: 0.92)
 #   --skip-layer N  reuse existing pipeline intermediate from layer N (1..3)
 #   --verify    run Whisper self-check after render
+#   --allow-inline-llm-rewrite  standalone/headless fallback: let the
+#               backend shell out to an isolated `claude --print --safe-mode`
+#               for the L1 narrative rewrite when no driving Claude Code
+#               agent is present to dispatch a rewrite subagent (see
+#               SKILL.md for the recommended, non-fallback workflow)
+#   --no-lyrics skip embedding narrative.txt as an ID3 USLT lyrics frame
+#               (default: embedded — the spoken text travels inside the
+#               MP3 for debugging/comparison against the source)
 #   --help      show this message
 
 set -euo pipefail
@@ -23,6 +31,8 @@ VOICE=""
 SPEED=""
 SKIP_LAYER=0
 VERIFY=0
+ALLOW_INLINE_LLM_REWRITE=0
+NO_LYRICS=0
 INPUT_FILE=""
 OUTPUT_FILE=""
 
@@ -35,8 +45,10 @@ while [[ $# -gt 0 ]]; do
         --speed)    SPEED="$2";       shift 2 ;;
         --skip-layer) SKIP_LAYER="$2"; shift 2 ;;
         --verify)   VERIFY=1;         shift   ;;
+        --allow-inline-llm-rewrite) ALLOW_INLINE_LLM_REWRITE=1; shift ;;
+        --no-lyrics) NO_LYRICS=1;     shift ;;
         --help|-h)
-            sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# //'
+            sed -n '2,21p' "${BASH_SOURCE[0]}" | sed 's/^# //'
             exit 0
             ;;
         -*)
@@ -85,6 +97,16 @@ if [[ ! -f "$BACKEND_SCRIPT" ]]; then
     exit 1
 fi
 
+# NOTE: gate on the VALUE of VERIFY, not its emptiness — VERIFY defaults to
+# the string "0", which is non-empty, so `${VERIFY:+--verify}` would always
+# expand and pass --verify regardless of whether the flag was given.
+VERIFY_FLAG=""
+[[ "$VERIFY" == "1" ]] && VERIFY_FLAG="--verify"
+INLINE_LLM_FLAG=""
+[[ "$ALLOW_INLINE_LLM_REWRITE" == "1" ]] && INLINE_LLM_FLAG="--allow-inline-llm-rewrite"
+NO_LYRICS_FLAG=""
+[[ "$NO_LYRICS" == "1" ]] && NO_LYRICS_FLAG="--no-lyrics"
+
 exec "$BACKEND_SCRIPT" \
     --input    "$INPUT_FILE" \
     --output   "$OUTPUT_FILE" \
@@ -92,4 +114,6 @@ exec "$BACKEND_SCRIPT" \
     --speed    "${SPEED}" \
     --skill-dir "${SKILL_DIR}" \
     --skip-layer "${SKIP_LAYER}" \
-    ${VERIFY:+--verify}
+    ${VERIFY_FLAG} \
+    ${INLINE_LLM_FLAG} \
+    ${NO_LYRICS_FLAG}


### PR DESCRIPTION
## Summary

Fixes from a fresh-machine field report on the `text-to-speech` skill's Kokoro TTS pipeline. Finding 2 was the priority; Findings 1/3/4 are fixes; Finding 5 is a feature added mid-session at the user's request.

- **Finding 2 (BREAKING, priority):** the L1 narrative rewrite no longer shells out to `claude --print` from inside `pipeline.py`/`chunk_and_rewrite.py` by default. Run inside an active Claude Code session, that nested call could inherit the session's output style / project `CLAUDE.md` and leak meta-commentary into the rewrite (observed: a literal `★ Insight` block rendered into audio). `SKILL.md` now instructs the driving agent to dispatch an isolated rewrite subagent (Agent/Task tool), write `narrative.txt`, then call `synth-audio.sh --skip-layer 1`. A bare invocation with no existing `narrative.txt` now fails loudly instead of silently falling back to the old inline behavior. Standalone/headless callers with no driving agent opt in via `--allow-inline-llm-rewrite` (isolated with `claude --print --safe-mode`). Added `validate_narrative()` in `pipeline.py` as a source-agnostic backstop (missing chapter markers, word-count collapse, known contamination patterns → hard fail, regardless of narrative source). Updated the stale `claude-sonnet-4-6` default to `claude-sonnet-5`.
- **Finding 1:** fixed `synth-audio.sh` always passing `--verify` to the backend (`${VERIFY:+--verify}` treated the default `VERIFY=0` as non-empty; now gated on value).
- **Finding 3:** `kokoro.sh` runs a probe-first espeak-ng data-path preflight (macOS) — it actually exercises `misaki`'s G2P once and only symlinks a Homebrew `espeak-ng` build (`$(brew --prefix espeak-ng)`) when that probe fails, staying silent otherwise. (Reworked from an earlier always-assume-broken version — see "Update" below.)
- **Finding 4:** `kokoro.sh` now requires `VIRTUAL_ENV` to be set and fails loudly with the fix instead of letting misaki's background `en-core-web-sm` auto-install fail deep with an unhelpful error.
- **Finding 5 (new, user request):** the rendered MP3's ID3 `USLT` frame now embeds the final `narrative.txt` (chapter markers stripped to plain title lines) by default — the spoken text travels inside the file for comparison against the source without a separate artefact. `--no-lyrics` opts out.

Skill version bumped 1.1.0 → 2.0.0 (major — Finding 2 is a breaking change to default behavior). Changeset and sessionlog included.

## Verification

- **Finding 2 primary path:** dispatched a real subagent from *within this session, which was running in explanatory output-style mode* — the exact failure condition from the field report — and confirmed it returned clean prose with chapter markers and no leaked `★ Insight` commentary.
- **Finding 2 gating:** ran `pipeline.py` for real — confirmed the negative gate (no `narrative.txt`, no `--allow-inline-llm-rewrite` → loud, informative failure) and the happy path (`--skip-layer 1` with a clean narrative → full L2/L3/`chapters.json`).
- **Finding 2 `validate_narrative()`:** ran three negative cases directly through `pipeline.py` — contaminated narrative (leaked `★ Insight` block) → hard fail; zero chapter markers despite source headings → hard fail; word-count collapse → hard fail.
- **Finding 2 inline fallback:** confirmed `--safe-mode` is actually present in the `claude` subprocess argv via a stub `claude` binary on `PATH`.
- **Finding 1:** stub backend that echoes its argv — confirmed `--verify` is absent by default and present when the flag is passed.
- **Finding 4:** confirmed the `VIRTUAL_ENV` precondition fires before any pipeline work starts.
- **Finding 5:** `inject_chapters.py`'s self-test extended and passing (fresh USLT write, idempotent re-inject, marker-stripping); standalone CLI tested for default sibling-file detection and `--no-lyrics` suppression.
- `pnpm test` (skill frontmatter validation across the whole repo) passes.

Full details and the rationale behind each design decision (e.g. `--safe-mode` vs `--bare`, the 20% word-count floor, gate-vs-delete for the inline fallback) are in the sessionlog.

## Update: real end-to-end render + F3 rework (no longer sandbox-only)

The original PR was verified in a sandbox without `kokoro`/`misaki`/`mutagen` installed, so actual Kokoro-82M speech synthesis wasn't exercised — that gap is now closed. Built a real `uv venv` on mac-zrh, installed the skill's deps (reusing the cached HF model weights, no re-download), dispatched a real L1 rewrite subagent, and ran an actual render through `synth-audio.sh --skip-layer 1`. Verified on the produced MP3:

- **Audio renders:** 40.2s duration, non-silent (`ffmpeg -af volumedetect`: mean −23.6dB, max −2.4dB), clean full-file decode (no truncation/corruption).
- **ID3 CHAP/CTOC chapters:** present, correctly timed.
- **USLT lyrics frame:** present, text matches marker-stripped `narrative.txt` exactly.

Doing the real render (not just isolated component tests) surfaced two more pre-existing bugs, both fixed:

1. **`kokoro_round5.py`:** the H1-title-only marker that precedes the first H2 marker with no body of its own (the standard convention from `narrative-chapter-focused.md`) was getting a zero-duration chapter entry pinned at the same timestamp as the next real chapter — `inject_chapters.py`'s own duration check correctly rejected it (`ValueError: chapter 0 has non-positive duration: 0..0`). Fixed by only creating a chapter entry for parts that actually have audio.
2. **`inject_chapters.py`:** the marker-stripping regex used `\s*` on its outer edges; since Python's `\s` matches `\n`, it ate the blank line between two back-to-back markers and mashed their titles together with no separator (`"The Habit of Small WinsWhy Momentum Matters"`). Narrowed to `[ \t]*` (horizontal whitespace only). My original self-test didn't catch this because it only checked round-trip consistency against the function's own output — strengthened it to assert an exact hand-written expected string.

Also reworked Finding 3's preflight: empirically confirmed (byte-identical dylib+data, verified via `shasum`) that the bundled espeak-ng data path is **not** reliably broken everywhere — it worked from a normally-located venv and failed from one nested under an unusually long path, on the same machine. The preflight is now probe-first (actually exercises `misaki`'s G2P before deciding) instead of always assuming it's broken, and stays silent when nothing needs fixing.

Full details in the sessionlog.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
