### PR TITLE
apple-mail: document attachment extraction and tell-block gotchas

### DIFF
--- a/.changeset/apple-mail-attachments.md
+++ b/.changeset/apple-mail-attachments.md
@@ -1,0 +1,15 @@
+---
+"@eins78/agent-skills": minor
+---
+
+`apple-mail`: document attachment extraction and two `tell`-block gotchas
+
+Adds `List attachments` / `Save attachments` commands and a gotchas section
+covering `POSIX file` failing inside a `tell application "Mail"` block (-1728)
+and the set of ordinary variable names that collide with Mail's terminology.
+
+<!--
+bumps:
+  skills:
+    apple-mail: minor
+-->

--- a/skills/apple-mail/README.md
+++ b/skills/apple-mail/README.md
@@ -54,10 +54,31 @@ osascript -e 'tell application "Mail" to get name of every account'
 
 # Verify inbox access
 osascript -e 'tell application "Mail" to count messages of inbox'
+
+# Verify attachment listing (pick a subject you know has an attachment)
+osascript -e 'tell application "Mail"
+  set msg to item 1 of (messages of inbox whose subject contains "invoice")
+  repeat with a in (mail attachments of msg)
+    log (name of a)
+  end repeat
+end tell'
 ```
+
+The attachment commands added in 1.1.0 were verified end-to-end against a real
+mailbox: listing, saving four attachments across four messages via the `my
+posixTarget(…)` handler, and byte-size comparison against the originals. The two
+gotchas were confirmed by reproducing each failure and its fix.
+
+## Known Gaps
+
+- **Terminology collisions are only partly enumerated.** The reserved-word list in
+  SKILL.md was found by probing common identifiers, not by reading Mail's `.sdef`.
+  Generating the full list from the dictionary would be more reliable.
+- **No write operations by design** — see Limitations.
 
 ## Future Improvements
 
 - Script for structured JSON output from mail queries
 - Mailbox-specific search helpers
 - Unread count per account
+- Helper script for bulk attachment extraction with name sanitization

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -119,6 +119,58 @@ end tell'
 osascript -e 'tell application "Mail" to get name of every mailbox of account "Gmail"'
 ```
 
+### List attachments
+
+```bash
+osascript -e 'tell application "Mail"
+  set msg to item 1 of (messages of inbox whose subject contains "invoice")
+  set out to ""
+  repeat with a in (mail attachments of msg)
+    set out to out & (name of a) & " [" & (file size of a) & " bytes]" & linefeed
+  end repeat
+  return out
+end tell'
+```
+
+### Save attachments
+
+Build the file target **outside** the `tell` block — via a handler called with `my`, so it still works inside a loop:
+
+```bash
+osascript <<'EOF'
+on posixTarget(p)
+  return POSIX file p
+end posixTarget
+
+set outDir to "/tmp/attachments/"   -- must already exist
+tell application "Mail"
+  repeat with m in (messages of inbox whose subject contains "invoice")
+    repeat with a in (mail attachments of m)
+      save a in (my posixTarget(outDir & (name of a)))
+    end repeat
+  end repeat
+end tell
+EOF
+```
+
+`outDir` must already exist — `save` into a missing directory fails with the uninformative `-10000 AppleEvent handler failed`, which says nothing about the path. `mkdir -p` first.
+
+Attachment names often contain `:` (e.g. `SOA-2026-08-02-12:20:06.xlsx`). It saves fine, but Finder and many tools render it as `/` — sanitize with `text item delimiters` if the name is going anywhere else.
+
+Fallback: `source of msg` returns the raw MIME, so Python's `email` module can extract parts without AppleScript at all. Useful when a mailbox is wedged or names need heavy cleanup.
+
+## Gotchas inside `tell application "Mail"`
+
+Both of these have one root cause: **unqualified terms resolve against Mail's dictionary, not AppleScript's.**
+
+**1. `POSIX file` fails.** Written inside the block it errors `-1728 Can't get POSIX file "…"` — Mail tries to resolve it as one of its own objects. Coerce outside the block or via `my` (see above). Note the error names the path, so it reads like a missing-file problem; it isn't.
+
+**2. Ordinary variable names are reserved.** These all fail inside the block, with `-10003`, `-10006`, or the unguessable `Can't set «constant ldaslsba» to …`:
+
+`base` · `name` · `subject` · `content` · `file` · `path` · `index` · `size` · `date` · `text` · `character`
+
+Prefix them — `basePath`, `msgSubject`, `outFile`. The failure is a *syntax* error at compile time for some (`base`, `file`, `date`, `text`, `character`) and a *runtime* error for others (`name`, `subject`, `content`, `index`, `size`), so a script can parse cleanly and still blow up mid-loop.
+
 ## Notes
 
 - AppleScript `messages of inbox` returns a unified inbox across all accounts


### PR DESCRIPTION
The `apple-mail` skill had **no attachment guidance at all**. Hitting that gap in real use surfaced two failures that are genuinely hard to diagnose from their error text — and both turn out to have the same root cause:

> Inside a `tell application "Mail"` block, unqualified terms resolve against **Mail's dictionary**, not AppleScript's.

## What's added

**Two commands** — `List attachments` and `Save attachments`. The save pattern builds the file target via a handler called with `my`, so it still works inside a loop:

```applescript
on posixTarget(p)
  return POSIX file p
end posixTarget

set outDir to "/tmp/attachments/"
tell application "Mail"
  repeat with m in (messages of inbox whose subject contains "invoice")
    repeat with a in (mail attachments of m)
      save a in (my posixTarget(outDir & (name of a)))
    end repeat
  end repeat
end tell
```

**A gotchas section** covering:

1. **`POSIX file` fails inside the block** — `-1728 Can't get POSIX file "…"`. The error *names the path*, so it reads like a missing-file problem. It isn't.

2. **Ordinary variable names are reserved** — `base`, `name`, `subject`, `content`, `file`, `path`, `index`, `size`, `date`, `text`, `character`. Worth noting the split: some fail at *compile* time, others at *runtime*, so a script can parse cleanly and still blow up mid-loop. `base` produces the unguessable `Can't set «constant ldaslsba» to …`.

3. **Missing target directory** → the opaque `-10000 AppleEvent handler failed`, which says nothing about the path.

4. Attachment names routinely contain `:` (`SOA-2026-08-02-12:20:06.xlsx`) — saves fine, renders as `/` elsewhere.

## Verification

Tested end-to-end against a real mailbox, not just reasoned about:

- Both new commands run **verbatim as written**
- Four attachments saved across four messages, byte sizes matching the originals
- Each gotcha reproduced, then confirmed fixed — the reserved-word list came from probing identifiers one at a time and reading each error

## Notes

- Version bump handled via changeset (`minor` — new sections). No manual `metadata.version` edit.
- `pnpm run validate` and `pnpm test` both pass.
- **Known gap**, recorded in the skill's README: the reserved-word list was found by probing common identifiers, not by parsing Mail's `.sdef`. Generating it from the dictionary would be more reliable and more complete.

Found while using the skill to read a billing statement; filed per the skill's own Self-Improvement section rather than working around it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grvsk2GJJUbp8W56Y6Epbv
