### PR TITLE
Codify the Kindle/EPUB pipeline: new send-to-kindle skill, pandoc EPUB recipe

### DIFF
--- a/.changeset/20260807-213500.md
+++ b/.changeset/20260807-213500.md
@@ -1,0 +1,18 @@
+---
+"@eins78/agent-skills": minor
+---
+
+Codify the Kindle/EPUB pipeline.
+
+- **`send-to-kindle`** — new skill (starts at `0.1.0`). Delivery routes and their 2026 status, EPUB-over-PDF rationale, per-device addressing, the approved-sender allowlist that drops mail silently, size ceilings, and the one-way nature of personal-document highlights. Documents the manual email step in three facts; ships no sender script and no configuration contract for one.
+- **`pandoc`** — adds `scripts/md2kindle-epub.sh` (markdown → e-reader EPUB with a real TOC, chapter splitting, and literal `[ ]` checkboxes), a "Markdown → Kindle EPUB" recipe, and a Common Mistakes row for the `task_lists` / Unicode-glyph trap: pandoc treats ☐/☑ as task-list markers unconditionally, so pre-converting them does not avoid `<input type="checkbox">` output.
+- **`dossier`** — one-line cross-reference to `send-to-kindle` in §DELIVER.
+
+`send-to-kindle` is intentionally absent from the bumps block below: its version is set directly in SKILL.md, and listing it would re-bump `0.1.0` to `0.1.1` on release.
+
+<!--
+bumps:
+  skills:
+    pandoc: minor
+    dossier: patch
+-->

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Collection of [Agent Skills](https://agentskills.io/) for Claude Code and compat
 | [pandoc](skills/pandoc/) | Document format conversion — 60+ formats via pandoc instead of ad-hoc scripts |
 | [pdf-zine](skills/pdf-zine/) | Convert a PDF into a fold-and-print booklet (zine) — A4 sheets, 2-up, fold to A5, via the `pdf2zine` Docker CLI |
 | [private-podcast-feed](skills/private-podcast-feed/) | Private MP3+RSS feed for self-subscription — itunes:block, token URLs, ID3 chapters, Overcast ping |
+| [send-to-kindle](skills/send-to-kindle/) | Getting a document onto a Kindle — delivery routes and 2026 status, EPUB over PDF, per-device addressing, the silently-dropped-sender trap, one-way highlights |
 | [text-to-speech](skills/text-to-speech/) | Convert a text document to an audio MP3 file via a local TTS pipeline (backend-configurable) |
 | [tmux-control](skills/tmux-control/) | Reliable tmux patterns — targeting, send-keys, capture-pane, wait-for sync, monitoring |
 

--- a/docs/sessionlogs/2026-08-07-kindle-codification.md
+++ b/docs/sessionlogs/2026-08-07-kindle-codification.md
@@ -1,0 +1,70 @@
+# Kindle/EPUB pipeline codified into two skills (PR #71)
+
+**Date:** 2026-08-07
+**Source:** Claude Code (Opus 5), delegated session
+**Session:** No compactions · ~20 min active · single task, spec supplied up front
+
+## Summary
+
+Implemented an already-approved plan: the Kindle/EPUB delivery experiment of 2026-08-06 became `skills/send-to-kindle/` (new, 0.1.0), a Markdown → Kindle EPUB recipe plus bundled script in `skills/pandoc/`, and a one-line cross-reference in `skills/dossier/`. Shipped as PR #71 — open, CI green, not merged.
+
+The spec was detailed and pre-decided, so there is little design rationale to preserve; the PR description and the two commit messages carry it. This log exists for three things that live outside those artifacts: a side effect on the machine's global skills, a secrets gate that nearly passed vacuously, and the unfinished half of a two-repo change.
+
+## 1. The secrets gate almost passed without checking anything
+
+The hard constraint was that no device serials, email addresses, or keychain account names reach either skill. The check run was:
+
+```bash
+git grep -nEi 'G000T6|GN433W|kindle-ingress|@icloud\.com|@178\.is|naomi' -- skills/
+```
+
+It returned clean. It was clean **because `git grep` only searches tracked files**, and `skills/send-to-kindle/` was entirely untracked at that moment — the one directory the check existed to inspect. The false clean was caught only because a sanity check (`grep -c 'kindle.com'` against a file known to contain the string) came back empty from `git grep` too, which made no sense.
+
+Re-run as plain `grep -rnEi … skills/`, it found the two real hits (see §2).
+
+A pre-commit secrets scan that skips new files is a gate that does not gate — precisely the failure mode `CLAUDE.md`'s "Gates Over Rules" section warns about, since the agent can honestly report "I ran the check." Worth a hook if this repo ever formalizes one: any secrets scan must either use `git grep --untracked` or plain `grep -r`, and should be given a known-positive canary to prove it can see the files it claims to have cleared.
+
+## 2. `KINDLE_TO` / `KINDLE_FROM`: flagged, rationalized past, then removed
+
+The narrowing in the approved plan was explicit: no env vars, no configuration contract for sending, and reintroducing them as future-proofing would be "smuggling back a decision Max just declined."
+
+The first draft of `skills/send-to-kindle/README.md` named both variables — inside a sentence stating they deliberately do not exist. That was flagged mid-write ("a stranger reading the README could copy those names as a suggested convention… borderline"), reasoned to be acceptable because it deters future reintroduction, committed, and then pre-defended in the PR body.
+
+It was wrong for a plain reason: naming both variables and describing their shape *is* the spec with a `not` in front, and it is the first thing a `grep KINDLE_` on the PR surfaces. Removed in `c8792f2`; the deterrent reasoning stays, worded without any token a reader could copy. Same commit trimmed a Known Gaps entry that had re-opened the AppleScript-vs-SMTP transport question, closed upstream as moot.
+
+The generalizable bit: *self-flagging a concern and then arguing yourself out of it in the same breath* is a stronger signal than the argument that follows it. The pre-emptive defence written into the PR body was the tell.
+
+## 3. Global skills were overwritten from this worktree
+
+`node_modules` was missing, so `pnpm install` ran — which fired the repo's own `postinstall` (`skills add . --global --skill '*' --agent claude-code`). That **copied this worktree's skills into `~/.claude/skills/`**, all stamped 21:34.
+
+Consequences until PR #71 merges:
+
+- The machine's global `pandoc` is the unmerged version (has `md2kindle-epub.sh`).
+- `send-to-kindle` is installed globally and live, from an unmerged branch.
+
+Harmless once merged. Remedy either way: `pnpm install` from the main checkout.
+
+Not a mistake exactly — `pnpm install` is the ordinary way to get a working tree — but it is a change outside the declared "this repo only" scope, produced by a `postinstall` that writes to `$HOME`. Worth knowing before running `pnpm install` in any worktree of this repo.
+
+## 4. The other half of this change is not done
+
+The plan spans two repos. Only this one was in scope:
+
+- **Done here:** the two skills, the dossier pointer, root README row, one changeset.
+- **Still pending in home-workspace (Max handles it after merge):** `git rm scripts/md2kindle-epub.sh`, update the dossier's usage block and `context/data.yaml:561`. The sessionlog, the 2026-08-06 digest, and `wiki/backlog.yaml` are to be left alone deliberately — the backlog entry cites the old path as evidence for the clippings-parser deferral, and rewriting it to match a later refactor would corrupt the record it exists to hold.
+
+Because that removal has not happened, `scripts/md2kindle-epub.sh` currently exists in both places. The approved decision was **move** (DEC-006); Max overrode it to copy-then-clean-up-himself. So the duplication is intentional and temporary, not drift — but it is drift the day the cleanup is forgotten.
+
+## Smaller notes
+
+- The script is byte-identical to the home original (`diff` clean, comment block included) and `shellcheck`-clean at default severity, so the "verbatim vs fix what shellcheck flags" tension never fired.
+- Its trailing comment points at `research/2026-08-06-kindle-delivery/`, a path that does not exist in this repo. Kept verbatim as instructed; the README provenance line resolves it by stating outright that the directory is private and not part of the repository.
+- `evals/` is not a per-skill convention — only `ballot` and `dossier` have eval suites — so `send-to-kindle` correctly ships without one.
+- `send-to-kindle` is hand-set to `0.1.0` and omitted from the changeset's `bumps:` block, per the known `increment_semver` behaviour: listing it would bump `0.1.0` → `0.1.1` on release.
+
+## Pending
+
+- [ ] Max: review and merge PR #71
+- [ ] Max: home-workspace cleanup (§4)
+- [ ] Optional: re-run `pnpm install` from the main checkout to restore global skills (§3)

--- a/skills/dossier/SKILL.md
+++ b/skills/dossier/SKILL.md
@@ -86,6 +86,8 @@ Before committing, run the reviewer checklist at `${CLAUDE_SKILL_DIR}/references
 - Commit dossier folder (`D:` intention per commit-notation).
 - **Do NOT end the session** — stay available for follow-ups, iterations, or additional dossiers.
 
+If the reader wants the dossier on an e-reader rather than on screen, see the `send-to-kindle` skill (and `pandoc`'s `md2kindle-epub.sh` for the file itself).
+
 ## Output Convention
 
 ```

--- a/skills/pandoc/README.md
+++ b/skills/pandoc/README.md
@@ -20,9 +20,16 @@ Pandoc handles 60+ input formats. File-type-based triggering would be either too
 
 The pandoc man page is 5200+ lines. The curated version in `references/` keeps the most useful sections (options, common variables, extensions overview) and cuts exhaustive per-format details. Agents can always run `man pandoc` or `pandoc --help` for the complete reference.
 
-### Mostly recipes, one bundled wrapper
+### Mostly recipes, a few bundled wrappers
 
-Pandoc's CLI is already the right interface for most conversions, so the skill is recipe-first. The one exception is the **compact A4 print** recipe (`scripts/md2pdf-print.sh` + `themes/marked-print.css`): it composes pandoc with headless Chrome to get Marked-2-style print output with full Japanese + emoji support, which no single pandoc PDF engine handles cleanly out of the box. Bundled because the composition is the value — agents would otherwise reinvent the wrapper each time.
+Pandoc's CLI is already the right interface for most conversions, so the skill is recipe-first. Two recipes are exceptions, both bundled because the *composition* is the value — agents would otherwise reinvent them each time:
+
+- **Compact A4 print** (`scripts/md2pdf-print.sh` + `themes/marked-print.css`) composes pandoc with headless Chrome to get Marked-2-style print output with full Japanese + emoji support, which no single pandoc PDF engine handles cleanly out of the box.
+- **Kindle EPUB** (`scripts/md2kindle-epub.sh`) fixes a specific set of flags — `--toc --toc-depth=3 --split-level=2` plus `-f markdown-task_lists` — that were arrived at empirically for e-reader output. The `task_lists` half in particular is a non-obvious finding (see Provenance) that a hand-written invocation reliably gets wrong.
+
+### Kindle delivery is a separate skill
+
+`md2kindle-epub.sh` produces the file and stops there. Everything about *getting it onto a device* — delivery routes, per-device addressing, the approved-sender allowlist, size ceilings — lives in the `send-to-kindle` skill. Those facts have a shelf life (four breaking changes between 2022 and 2026) and would otherwise version-bump `pandoc` every time Amazon moves something.
 
 ## File Structure
 
@@ -31,7 +38,8 @@ pandoc/
 ├── SKILL.md                          # Core skill (recipes, patterns, when-to-use)
 ├── README.md                         # This file
 ├── scripts/
-│   └── md2pdf-print.sh               # Markdown → A4 print PDF (pandoc + headless Chrome)
+│   ├── md2pdf-print.sh               # Markdown → A4 print PDF (pandoc + headless Chrome)
+│   └── md2kindle-epub.sh             # Markdown → e-reader EPUB (TOC, chapter split, literal checkboxes)
 ├── themes/
 │   └── marked-print.css              # Compact A4 print stylesheet for the wrapper
 ├── tests/
@@ -49,6 +57,7 @@ pandoc/
 - pandoc 3.x+ (tested with 3.9.0.2)
 - For PDF output: a LaTeX distribution (texlive, mactex, tectonic) or weasyprint/typst
 - For the **compact A4 print** recipe: Google Chrome (or Chromium). The wrapper defaults to the macOS app-bundle path (`/Applications/Google Chrome.app`); on Linux/Windows or non-default install locations, override with `CHROME=/path/to/chrome`. No LaTeX needed. Glyph fallback for Japanese + emoji is best on macOS where Apple's system font stack is available; other platforms work but the exact look depends on installed fonts.
+- For the **Kindle EPUB** recipe: pandoc only. No LaTeX, no Chrome, no Calibre — pandoc writes EPUB natively.
 - For running `tests/test-md2pdf-print.sh`: poppler (`brew install poppler`) for `pdfinfo` + `pdftotext`. The test skips cleanly if any tool is missing — it never fails CI on a machine that can't run it.
 - No other dependencies
 
@@ -79,11 +88,24 @@ pandoc/
 
    Override Chrome path with `CHROME=/path/to/chrome pnpm test:print`.
 
+7. **Kindle EPUB test (manual):** no automated test yet. Convert any markdown
+   file with `##` headings and a GFM checkbox list, then verify:
+
+   ```bash
+   skills/pandoc/scripts/md2kindle-epub.sh -o /tmp/out.epub some-doc.md
+   unzip -l /tmp/out.epub                     # mimetype first, one .xhtml per H2
+   unzip -p /tmp/out.epub EPUB/nav.xhtml      # TOC lists headings to depth 3
+   unzip -p /tmp/out.epub 'EPUB/text/*.xhtml' | grep -c 'input type="checkbox"'  # expect 0
+   ```
+
+   Add `--raw-checkboxes` and the last check should flip to non-zero.
+
 ## Provenance
 
 - Option reference curated from official pandoc 3.9.0.2 man page (`man pandoc`)
 - Recipes validated against actual pandoc invocations
 - Format lists from `pandoc --list-input-formats` and `pandoc --list-output-formats`
+- `md2kindle-epub.sh` and the `task_lists` / Unicode-glyph finding come from a 2026-08-06 Kindle delivery experiment run outside this repo (home-workspace `research/2026-08-06-kindle-delivery/`), which tested the script against a real 436-line dossier and a real 7-checkbox ballot, validated the resulting EPUB with `xmllint`, and confirmed on-device rendering. The script is copied here verbatim, comment block included.
 
 ## Known Gaps
 

--- a/skills/pandoc/SKILL.md
+++ b/skills/pandoc/SKILL.md
@@ -144,6 +144,29 @@ pandoc -t beamer -o slides.pdf input.md               # LaTeX Beamer
 pandoc -o book.epub chapter1.md chapter2.md metadata.yaml
 ```
 
+### Markdown → Kindle EPUB
+
+For markdown destined for an e-reader — reflowable text, adjustable font size,
+and a working table of contents. Produce EPUB, not PDF: a PDF page is a fixed
+canvas and only zooms/pans on a 6" screen, while Send-to-Kindle converts EPUB
+into the device's own reflowable format on delivery.
+
+```bash
+"${CLAUDE_SKILL_DIR}/scripts/md2kindle-epub.sh" -o out.epub input.md
+"${CLAUDE_SKILL_DIR}/scripts/md2kindle-epub.sh" -o out.epub part1.md part2.md --title "Report"
+"${CLAUDE_SKILL_DIR}/scripts/md2kindle-epub.sh" -o out.epub ballot.md --raw-checkboxes
+```
+
+The wrapper sets `--toc --toc-depth=3 --split-level=2` (a real table of
+contents; chapters split at each `##` so no single internal file gets huge)
+and disables the `task_lists` extension by default, so GFM checkboxes stay
+literal `[ ]` / `[x]` text instead of HTML `<input type="checkbox">` elements.
+Plain text is guaranteed to survive a server-side ebook conversion; form
+elements are not. `--raw-checkboxes` restores native task-list HTML.
+
+Getting the file onto a device is a separate concern — see the
+`send-to-kindle` skill for delivery routes, addressing, and size limits.
+
 ### Man page → Markdown
 
 ```bash
@@ -215,6 +238,7 @@ Always use `-s` for HTML files, LaTeX documents, and slide decks. DOCX/PDF/EPUB 
 | Wrong markdown flavor in output | Specify `-t gfm` or `-t commonmark` explicitly |
 | Piping binary formats to stdout | Use `-o file.docx` — DOCX/PDF/EPUB must write to files |
 | Line wrapping mangles output | Add `--wrap=none` to preserve original line breaks |
+| Checkboxes become `<input type="checkbox">` in EPUB/HTML | Read with `-f markdown-task_lists` to keep literal `[ ]` / `[x]` text. Pre-converting to Unicode glyphs (☐/☑) does **not** help — pandoc treats those as task-list markers unconditionally, independent of the extension flag, and still emits `<input>` |
 
 ## References
 
@@ -228,3 +252,4 @@ Consult for deep dives — these are loaded on demand, not auto-included:
 
 - `${CLAUDE_SKILL_DIR}/themes/marked-print.css` — Compact A4 print stylesheet (9pt body, GitHub-like headings, Japanese + emoji)
 - `${CLAUDE_SKILL_DIR}/scripts/md2pdf-print.sh` — Markdown → A4 print PDF via pandoc + headless Chrome
+- `${CLAUDE_SKILL_DIR}/scripts/md2kindle-epub.sh` — Markdown → e-reader EPUB (TOC, chapter splitting, literal checkboxes)

--- a/skills/pandoc/scripts/md2kindle-epub.sh
+++ b/skills/pandoc/scripts/md2kindle-epub.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Usage: md2kindle-epub.sh -o output.epub input.md [input2.md ...] [--title "Title"] [--raw-checkboxes]
+#
+# Converts markdown (dossier/ballot output, or any other markdown doc) to an
+# EPUB suitable for Send-to-Kindle delivery: reflowable text, adjustable
+# font size, and a working table of contents (built from heading levels;
+# --split-level=2 keeps individual chapter files small).
+#
+# GFM task-list checkboxes ("- [ ] foo") are left as literal "[ ]" / "[x]"
+# text by default (task_lists extension disabled on the reader) rather than
+# pandoc's native <input type="checkbox"> task-list HTML. Plain text is
+# guaranteed to survive Amazon's server-side EPUB->KFX conversion; whether
+# KFX preserves HTML form elements is untested against a real device. Note
+# that pre-converting to Unicode glyphs (☐/☑) does NOT dodge this: pandoc
+# recognizes those glyphs as task-list markers unconditionally, independent
+# of the task_lists extension flag, and still emits <input> for them.
+# Pass --raw-checkboxes to re-enable task_lists and get native <input>
+# checkboxes instead (try this if literal brackets look worse on-device).
+#
+# Background + test results: research/2026-08-06-kindle-delivery/
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 -o output.epub input.md [input2.md ...] [--title \"Title\"] [--raw-checkboxes]" >&2
+  exit 1
+}
+
+output=""
+title=""
+raw_checkboxes=0
+inputs=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    --title) title="$2"; shift 2 ;;
+    --raw-checkboxes) raw_checkboxes=1; shift ;;
+    -h|--help) usage ;;
+    *) inputs+=("$1"); shift ;;
+  esac
+done
+
+[ -n "$output" ] || usage
+[ "${#inputs[@]}" -gt 0 ] || usage
+
+from_format="markdown"
+[ "$raw_checkboxes" -eq 0 ] && from_format="markdown-task_lists"
+
+pandoc_args=(-f "$from_format" --toc --toc-depth=3 --split-level=2 -M lang=en-US -o "$output")
+[ -n "$title" ] && pandoc_args+=(-M "title=$title")
+
+pandoc "${pandoc_args[@]}" "${inputs[@]}"
+
+echo "Wrote $output"

--- a/skills/send-to-kindle/README.md
+++ b/skills/send-to-kindle/README.md
@@ -40,10 +40,11 @@ stay out.
 | The allowlist exists and drops mail silently | Which sender addresses are on it |
 | Highlights are one-way | Any keychain account name |
 
-Nothing personal is referenced *indirectly* either: there is no `KINDLE_TO` /
-`KINDLE_FROM` env-var contract. An env-var spec no code reads would document
-an interface that does not exist. If a sender is ever built, the contract gets
-designed then, against real code.
+Nothing personal is referenced *indirectly* either: there is deliberately no
+configuration contract for sending — no env vars, no config file, no keychain
+lookups. A configuration spec that no code reads would document an interface
+that does not exist. If a sender is ever built, its contract gets designed
+then, against real code.
 
 ### No sending, by decision not by omission
 
@@ -132,11 +133,9 @@ snippets and independent trackers, not read directly from the vendor.
 - **The ~50 MB email ceiling is community-sourced and unverified** against an
   official page. Flagged as such in SKILL.md rather than stated flatly. A
   30-second check on the Personal Document Settings page would settle it.
-- **No sender automation** — deliberate, see Design Decisions. If it is ever
-  built, the open sub-question is transport: AppleScript against Mail.app
-  (reuses the user's already-approved identity, but macOS-only and needs the
-  app awake) versus SMTP (portable and headless-capable, but needs credentials
-  and an allowlisted sender).
+- **No sender automation** — deliberate, see Design Decisions. Building one
+  would be a new capability with its own transport decision to make, not a
+  chore left undone here.
 - **No `My Clippings.txt` parser** — deliberately deferred. The format is a
   well-documented plain-text convention, so this is a small follow-up when
   there are real clippings to parse, not a research question.

--- a/skills/send-to-kindle/README.md
+++ b/skills/send-to-kindle/README.md
@@ -1,0 +1,157 @@
+# send-to-kindle Skill — Development Documentation
+
+## Purpose
+
+Carries the service and device knowledge needed to get a document onto a
+Kindle: which delivery routes still work, what format to produce, and the two
+failure modes that produce no error message (silently-dropped mail from an
+unapproved sender, and per-device addressing selected by a misleading display
+name). It also records the one hard limit — highlights on personal documents
+never reach the cloud.
+
+The skill stops short of sending. It documents the manual email step in three
+facts and ships no sender code.
+
+**Tier:** Published (beta) — available in the
+[eins78/agent-skills](https://github.com/eins78/agent-skills) plugin
+
+## Design Decisions
+
+### Separate from `pandoc`, not folded into it
+
+`pandoc` owns file *production* (`scripts/md2kindle-epub.sh` makes the EPUB);
+this skill owns *delivery*. The split is not tidiness — it is versioning.
+Amazon's ingestion behaviour changed four times between 2022 and 2026 (MOBI
+input dropped, EPUB input added, USB download of purchased books removed,
+Word's button retired). Facts with that shelf life need their own version and
+changelog. Folding them into `pandoc` would version-bump a document-conversion
+skill every time Amazon moves something unrelated to pandoc.
+
+### Generic knowledge only, by an explicit test
+
+The dividing line applied throughout: *would a stranger installing this from
+the marketplace change a **value** or the **logic**?* Values are personal and
+stay out.
+
+| Carried here | Deliberately absent |
+|---|---|
+| Routes and their 2026 status | Any `…@kindle.com` ingress address |
+| Per-device addressing as a *rule* | Which devices exist, their serials, their names |
+| The allowlist exists and drops mail silently | Which sender addresses are on it |
+| Highlights are one-way | Any keychain account name |
+
+Nothing personal is referenced *indirectly* either: there is no `KINDLE_TO` /
+`KINDLE_FROM` env-var contract. An env-var spec no code reads would document
+an interface that does not exist. If a sender is ever built, the contract gets
+designed then, against real code.
+
+### No sending, by decision not by omission
+
+Documented in SKILL.md under "What this skill deliberately does not do" so a
+future session does not read the gap as an oversight and helpfully fill it.
+
+### Statuses are date-stamped in the body
+
+Every route table says "as of 2026-08" in the heading rather than relying on
+the git log. A skill installed from a marketplace has no git log.
+
+### No globs
+
+Nothing about a file's extension implies e-reader intent. Description triggers
+carry the discovery load.
+
+## File Structure
+
+```
+send-to-kindle/
+├── SKILL.md       # Format choice, routes, the three send facts, size limits, highlights
+└── README.md      # This file
+```
+
+No scripts, no references, no themes — see "No sending" above. The one script
+in this pipeline (`md2kindle-epub.sh`) lives with the `pandoc` skill.
+
+## Dependencies
+
+None. This is a reference skill — no binaries, no services, no credentials.
+
+The companion `pandoc` skill needs pandoc 3.x to produce the EPUB. The USB
+route mentions Calibre for local AZW3 conversion, but that path is documented,
+not automated.
+
+## Testing
+
+1. **Trigger test:** "how do I get this onto my Kindle?" → skill should load
+2. **Trigger test (failure symptom):** "I emailed a file to my Kindle and it
+   never arrived" → skill should load and surface the approved-sender rule
+   before suggesting anything else
+3. **Format test:** "make a PDF for my Kindle" → agent should push back toward
+   EPUB and give the reflowable-vs-fixed reason
+4. **Composition test:** "convert this markdown and send it to my Kindle" →
+   agent should use the `pandoc` skill's `md2kindle-epub.sh` for the file and
+   this skill for the delivery step, and should *not* invent a sender script
+5. **Boundary test:** "automate sending this to my Kindle every morning" →
+   agent should state that no sender exists and that building one is a
+   decision, not a chore
+6. **Highlights test:** "sync my Kindle highlights from that document to
+   Readwise" → agent should identify this as structurally impossible for
+   personal documents, not attempt a workaround
+
+The delivery pipeline itself was verified end-to-end on 2026-08-06 (see
+Provenance) — samples were mailed to a real device and rendered correctly.
+That verification happened outside this repo and is not reproducible from it.
+
+## Provenance
+
+Every fact traces to a research dossier produced 2026-08-06 in the author's
+private workspace, at `research/2026-08-06-kindle-delivery/`. **That directory
+is not part of this repository** and is not publicly available; it is cited
+here for the author's own audit trail.
+
+Within it, the load-bearing sources were:
+
+- Route statuses and the pre-2013 wireless cutoff: The Ebook Reader blog
+  (2026-04-13, 2026-06-12) and Good e-Reader (2025), both quoting Amazon's own
+  help pages
+- EPUB accepted but converted server-side: TechRadar, plus Vellum's
+  contemporaneous 2022 write-up of the EPUB-acceptance rollout
+- Personal-document highlights excluded from the cloud Notebook: MobileRead
+  forum consensus, corroborated by Readwise's own scope documentation
+- Size ceilings: a single community guide (see Known Gaps)
+- Per-device addressing and the silent-drop behaviour: confirmed in practice
+  on 2026-08-06 when the samples were sent
+
+**Evidence-quality caveat carried over from the dossier:** Amazon's own
+`amazon.com/gp/help/...` pages returned HTTP 503 to every automated fetch
+attempted during that research — direct curl, headless Chrome, and a reader
+proxy alike. Amazon-sourced statements here are corroborated through search
+snippets and independent trackers, not read directly from the vendor.
+
+## Known Gaps
+
+- **The ~50 MB email ceiling is community-sourced and unverified** against an
+  official page. Flagged as such in SKILL.md rather than stated flatly. A
+  30-second check on the Personal Document Settings page would settle it.
+- **No sender automation** — deliberate, see Design Decisions. If it is ever
+  built, the open sub-question is transport: AppleScript against Mail.app
+  (reuses the user's already-approved identity, but macOS-only and needs the
+  app awake) versus SMTP (portable and headless-capable, but needs credentials
+  and an allowlisted sender).
+- **No `My Clippings.txt` parser** — deliberately deferred. The format is a
+  well-documented plain-text convention, so this is a small follow-up when
+  there are real clippings to parse, not a research question.
+- **Whether the device's format conversion preserves HTML `<input>` elements
+  is untested.** The `pandoc` wrapper sidesteps it by emitting literal `[ ]`
+  text; nobody has confirmed what happens if you don't.
+- **Amazon-specific.** Kobo, reMarkable, and Pocketbook all have their own
+  ingestion stories and none of them are covered here.
+- No coverage of the Kindle's own document management (collections, deleting
+  personal documents from the cloud, re-delivery to a second device).
+
+## Future Improvements
+
+- Re-verify the route table when a dated claim ages past ~12 months, or on the
+  next observed breakage
+- Fold in Kobo / reMarkable delivery if a second device type ever enters use,
+  or rename the skill if it stops being Kindle-specific
+- A `My Clippings.txt` parser, at the point where clippings actually exist

--- a/skills/send-to-kindle/SKILL.md
+++ b/skills/send-to-kindle/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: send-to-kindle
+description: >-
+  Use when getting a document onto a Kindle or e-reader — which delivery
+  routes still work, what format to produce, and why a delivery can silently
+  fail. Triggers: send to Kindle, put this on my Kindle, read on Kindle,
+  Kindle email address, sendtokindle, personal documents, sideload EPUB,
+  Kindle didn't receive it, kindle.com address, e-reader delivery, Kindle
+  highlights, My Clippings.
+globs: []
+compatibility: claude-code, cursor
+license: MIT
+metadata:
+  author: eins78
+  repo: https://github.com/eins78/agent-skills
+  version: "0.1.0"
+---
+
+# send-to-kindle
+
+Delivering a document to a Kindle. Covers what to produce, how it gets there,
+and the two failure modes that give no error message.
+
+Producing the file is the `pandoc` skill's job —
+`scripts/md2kindle-epub.sh` turns markdown into a suitable EPUB. This skill
+starts at "the file exists".
+
+**Everything below is service behaviour, and it moves.** Between 2022 and 2026
+Amazon stopped accepting MOBI, started accepting EPUB, killed USB download of
+purchased books, and retired Word's Send-to-Kindle button. Statuses here are
+**as of 2026-08**; re-verify before relying on a dated claim.
+
+## Produce EPUB, not PDF
+
+| | |
+|---|---|
+| **EPUB** | Reflowable — text re-wraps to the reader's font size and margins. Kindles do not render EPUB natively; Send-to-Kindle converts it server-side into the device's own format (KFX/AZW3) on delivery, which is what buys reflow, resizable type, and a native TOC. Free, no local tooling. |
+| **PDF** | Fixed-layout. A PDF page is a fixed canvas — on a 6" screen it either shrinks to illegible or needs constant pan/zoom. Right for print, wrong for reading. An A5 print booklet is roughly 60% wider than a Paperwhite's visible area. |
+| **MOBI / AZW** | Not accepted as *input* since August 2022. Don't reach for an old MOBI recipe. |
+| **AZW3 (locally converted)** | Only needed for the USB path — see below. |
+
+## Delivery routes (status as of 2026-08)
+
+| Route | Status | Notes |
+|---|---|---|
+| **Send-to-Kindle email** (`…@kindle.com`) | Works | The default. Wireless, works over a phone hotspot. See the three facts below |
+| **Web upload** (sendtokindle.com, drag-and-drop) | Works | Manual, but no sender allowlist to trip over |
+| **Kindle mobile app → "Import file"** | Works | Only useful if the reader reads on the phone |
+| **USB sideload into `documents/`** | Works | A raw `.epub` copied over USB is **not indexed** by the Kindle library — convert to AZW3 locally first (e.g. Calibre). Email delivery gets that conversion for free. Unaffected by the 2025 removal of USB *download* for purchased Kindle Store books, which is a different thing |
+| **Send to Kindle desktop app** | Being retired | Kindle for PC and the Windows desktop app shut down 2026-06-30. Email and web upload do not depend on it |
+| **Send to Kindle from Microsoft Word** | Retired 2026-02-09 | The button is gone; web upload is unaffected |
+| **Wireless delivery to older hardware** | Cut off for pre-2013 devices | The May-2026 cutoff hit Paperwhite 1 and older only. 2018-era hardware and newer keep full wireless delivery |
+
+## Sending by email — three facts
+
+1. **Send the file as an email attachment** to the reader's Send-to-Kindle
+   address. Nothing else in the message matters.
+2. **Addresses are per device, not per account.** An account with several
+   registered Kindles has a separate ingress address for each, so delivery is
+   granular. Amazon-facing *device names* are user-set and can be misleading —
+   pick the target by a stable identifier (the address itself, or the device
+   serial), never by display name.
+3. **The sender address must be pre-approved** on the account's Approved
+   Personal Document E-mail List. Mail from an unapproved sender is **dropped
+   silently — no bounce, no error, no delivery.** This is the single most
+   likely cause of "I sent it and nothing arrived".
+
+The allowlist is separate from the ingress address; both live under
+*Manage Your Content and Devices → Preferences → Personal Document Settings*.
+
+## Size ceilings
+
+| Route | Ceiling |
+|---|---|
+| Email attachment | **~50 MB** — widely-circulated community figure, not confirmed against an official Amazon page. Verify on the Personal Document Settings page if it matters |
+| Web upload | ~200 MB, same caveat |
+
+Text documents will not come near either. A document bundling archived source
+captures plausibly could.
+
+## Highlights only come back one way
+
+Anything delivered via Send-to-Kindle is a **personal document**, not a Kindle
+Store purchase, and Amazon's cloud highlight ecosystem is structurally closed
+to it:
+
+| Route | Covers personal documents? |
+|---|---|
+| `documents/My Clippings.txt` on the device | **Yes — the only route.** Plain text, trivially parseable, but retrieval requires physically connecting the device over USB. No wireless path exists for this file |
+| `read.amazon.com/notebook` (web Notebook) | No — Kindle Store purchases only |
+| Per-book "Export Notes and Highlights" | No — same scope, and manual anyway |
+| Readwise | No — its docs explicitly exclude files sent via Send-to-Kindle |
+
+So the USB cable is not a convenience fallback here; it is the only mechanism.
+Plan around a manual step, or do not promise highlight round-tripping.
+
+## Common Mistakes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Sent it, nothing arrived, no bounce | Sender not on the approved list | Add the exact sending address under Personal Document Settings |
+| Arrived on the wrong person's Kindle | Targeted by device display name | Target by ingress address or serial; names are user-set and often stale |
+| Reader has to pan and zoom every page | A PDF was sent | Send EPUB and let Send-to-Kindle convert it |
+| Copied an `.epub` over USB, it never appears in the library | Raw EPUB isn't indexed on-device | Convert to AZW3 locally, or use email delivery instead |
+| Checkboxes render as blank gaps | Task-list HTML `<input>` elements were emitted | See the `pandoc` skill — build the EPUB with `task_lists` disabled |
+| Waiting for highlights to sync | Personal documents never reach the cloud | USB + `My Clippings.txt`, or nothing |
+
+## What this skill deliberately does not do
+
+- **It does not send anything.** No sender script, no AppleScript, no SMTP
+  helper, and no configuration contract for one. The send step is the three
+  facts above, performed by a human in a mail client.
+- **It carries no addresses.** Ingress addresses, approved senders, device
+  serials, and keychain account names are personal values that belong in the
+  operator's own private workspace, never in a published skill.


### PR DESCRIPTION
Codifies the 2026-08-06 Kindle/EPUB delivery experiment into this repo, per the approved plan of 2026-08-07.

The split follows a **versioning boundary**, not a topical one: `pandoc` owns file production, which is stable, while `send-to-kindle` owns delivery, which broke four times between 2022 and 2026 (MOBI input dropped, EPUB input added, USB download of purchased books removed, Word's button retired). Folding delivery into `pandoc` would version-bump a document-conversion skill every time Amazon moves something unrelated to pandoc.

## `skills/pandoc/`

- **`scripts/md2kindle-epub.sh`** — copied **verbatim** from the home-workspace original, comment block included. `shellcheck` clean at default severity, no changes required. Mode 755, verified in the index.
- **"Markdown → Kindle EPUB" recipe** in SKILL.md, using the `-o` form the script actually accepts.
- **Common Mistakes row** for the non-obvious finding: pandoc treats Unicode ballot glyphs (☐/☑) as task-list markers *unconditionally, independent of the `task_lists` extension flag*, so pre-converting `[ ]` to a glyph does **not** avoid `<input type="checkbox">` output. Disabling `task_lists` on the reader is the only thing that works.
- **Bundled Assets** entry.
- **README.md** — File Structure tree, dependencies, a manual smoke test, and provenance. The "Mostly recipes, one bundled wrapper" design note is now "a few bundled wrappers" — heading *and* body, since that sentence stopped being true when the second script landed.

Smoke-tested during development: TOC lists headings to depth 3 across split chapter files, `##` splitting produces one `.xhtml` per section, default output contains 0 `<input type="checkbox">` elements and literal `[ ] alpha` text, `--raw-checkboxes` flips it to 2.

## `skills/send-to-kindle/` (new, 0.1.0)

Delivery routes with their 2026 status (date-stamped in the body — an installed skill has no git log), EPUB-over-PDF rationale, per-device addressing, the approved-sender allowlist that drops mail **silently with no bounce**, size ceilings, and the one-way nature of personal-document highlights.

**Scope boundaries, deliberate and documented in the skill so a future session does not read them as oversights:**

- **The send step is three facts** — attach the file to an email, addresses are per device not per account, the sender must be pre-approved or the mail vanishes. No sender script, no AppleScript, no SMTP helper.
- **No configuration contract for sending** — no env vars, no config file, no keychain lookups. With nothing to configure, a spec would document an interface no code reads. The dev README records the *reasoning* so a future session does not reintroduce one as future-proofing, without naming any variable a reader could copy.
- **No `My Clippings.txt` parser** — deferred until there are clippings to parse.
- **No personal values anywhere** — no ingress addresses, approved senders, device serials, or keychain account names, in either skill. Verified by grep over `skills/`.

The ~50 MB email ceiling is carried **with its caveat intact**: it is a community-sourced figure that the source research could not confirm against an official Amazon page (their help subdomain 503'd every automated fetch). Laundering a caveated figure into a flat fact seemed worse than saying so.

README covers purpose, tier, design decisions, file structure, dependencies (none), six trigger/boundary tests, provenance, and known gaps. Provenance points at the source research in the author's private workspace and states plainly that the directory is **not part of this repository**, so nobody hunts for a missing path.

## `skills/dossier/`

One line in §DELIVER pointing at `send-to-kindle`. A pointer, not an integration step — `dossier`'s value is that it is domain-agnostic.

## Versioning

One changeset: package `minor`, with `pandoc: minor` and `dossier: patch` in the `bumps:` block. `send-to-kindle` is **intentionally absent** from that block — its version is set directly in SKILL.md at `0.1.0`, and listing it would have `increment_semver` re-bump it to `0.1.1` on release.

No manual edits to `package.json`, `marketplace.json`, or either `plugin.json`.

## Verification

```
shellcheck skills/pandoc/scripts/md2kindle-epub.sh    # clean
diff <home original> <copy>                           # identical
grep -rnEi <serials|keychain names|addresses> skills/ # no matches
pnpm test                                             # exit 0, send-to-kindle listed
pnpm run validate                                     # All skills valid (0 warnings)
```

## Out of scope

Home-workspace cleanup (removing the original script, updating its two live references) is handled separately by the author after merge. `scripts/md2kindle-epub.sh` is left in place there; this PR copies rather than moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
