### PR TITLE
apple-mail: document archive search over .emlx (fixes silent zero-result traps)

### DIFF
--- a/.changeset/20260807-222344.md
+++ b/.changeset/20260807-222344.md
@@ -1,0 +1,21 @@
+---
+"@eins78/agent-skills": minor
+---
+
+**`apple-mail`** — document archive search over `.emlx`, the preferred path for old mail or many accounts. Closes #69.
+
+- New **Searching large archives** section: a `ripgrep` recipe over `~/Library/Mail`, the `.emlx` format (length prefix + RFC822 + plist trailer), and triage via a new `scripts/emlx.py`. AppleScript stays the path for live and recent-inbox queries, cross-referencing the existing bridge-hang warning rather than repeating it.
+- Warns that `mdfind -onlyin ~/Library/Mail` returns **0 for every query** because the store is not Spotlight-indexed — 0 reads as "no such mail" but means "no index", and that misreading is the bug. Ships `mdutil -s /` + `mdls -name kMDItemTextContent` as the diagnostic that tells the two apart.
+- Same trap found in the fix itself: without Full Disk Access, `rg --no-messages` also returns a silent 0. The recipe now opens with a readability precheck instead of a prose caveat.
+- Documents MIME-encoded (`=?UTF-8?B?...?=`) and folded headers, which raw `grep` cannot handle — measured at ~24% and ~20% of messages on the authoring machine, so a `grep`/`cut` pipeline is wrong for roughly a third of them.
+- Documents `*.partial.emlx`: included by `-g '*.emlx'` automatically, and worth searching. Corrects the reported claim that they lack the body — measurement shows text bodies intact and only attachment parts stubbed (empty payload plus `X-Apple-Content-Length`), surfaced as a `NOT-DOWNLOADED` flag.
+- New `tests/test-emlx.sh` — smoke test over a synthetic fixture, no real mail touched. Not run by `pnpm test`.
+- README: archive-search row in the approach table, Full Disk Access dependency, silent-failure limitations, and a table recording which issue #69 recipes verified and which were corrected.
+
+Read-only throughout: nothing added sends, deletes, or modifies mail.
+
+<!--
+bumps:
+  skills:
+    apple-mail: minor
+-->

--- a/skills/apple-mail/README.md
+++ b/skills/apple-mail/README.md
@@ -12,43 +12,90 @@ Project-specific skill for reading email via Mail.app AppleScript integration.
 
 ## Architecture
 
-Uses AppleScript via `osascript` to interact with Mail.app. This is the only reliable way to access Apple Mail programmatically on macOS without third-party dependencies.
+Two access paths, chosen by workload:
 
-### Why AppleScript?
+- **AppleScript via `osascript`** — live state (unread counts, recent inbox, account
+  and mailbox names) and attachment extraction. Nothing else exposes Mail's live
+  view, or its decoded attachments, without third-party dependencies.
+- **`ripgrep` over the `.emlx` files** — archive search. Mail stores every message
+  as a file under `~/Library/Mail/`, so the archive is greppable directly.
+
+They are complementary rather than alternatives: the archive path *locates* a
+message across a large store, and the AppleScript path *acts* on it once found.
+
+### Why not one path for everything?
 
 | Approach | Pros | Cons |
 |----------|------|------|
-| **AppleScript** (chosen) | Zero dependencies, full Mail.app access | Verbose syntax, requires Mail.app running |
+| **AppleScript** (live queries, attachments) | Zero dependencies, full Mail.app access, sees live state, only path that extracts attachments | Verbose, requires Mail.app running, bridge hangs intermittently, cross-account search degrades badly with account count, `tell`-block terminology collisions |
+| **ripgrep over `.emlx`** (archive search) | Fast over the whole archive, no Mail.app, no hangs | Needs Full Disk Access; on-disk only; cannot extract attachments, and attachment text is base64 so it never matches |
+| **Spotlight / `mdfind`** | Would be instant | **Does not work** — `~/Library/Mail` is not indexed; every query returns 0 |
 | **IMAP direct** | Works headless, more portable | Requires credentials, no unified inbox |
 | **mailutil CLI** | Simpler syntax | Limited functionality |
+
+`mdfind` is listed because its failure is silent: 0 results is indistinguishable
+from a true negative unless you already know the store is unindexed. That
+misreading is the bug this path exists to prevent.
 
 ## Skill Structure
 
 ```
 apple-mail/
-├── SKILL.md    # User-facing skill reference
-└── README.md   # This file
+├── SKILL.md              # User-facing skill reference
+├── README.md             # This file
+├── scripts/
+│   └── emlx.py           # .emlx parser: `list` (triage TSV) and `show` (one message)
+└── tests/
+    └── test-emlx.sh      # Smoke test against a synthetic fixture
 ```
+
+### Why a parser instead of a shell pipeline
+
+Raw `grep` finds the right files but cannot report them. Measured against a real
+multi-account store on the authoring machine: ~24% of `Subject:` headers are
+MIME-encoded (`=?UTF-8?B?...?=`) and ~20% are folded onto continuation lines, so a
+`grep -m1 '^Subject:' | cut -c10-` pipeline is wrong for roughly a third of
+messages. `email.policy.default` handles encoding, folding, charsets, and
+transfer-encoding in one step.
 
 ## Origin
 
 Extracted from [clawd-workspace TOOLS.md](https://github.com/eins78/clawd-workspace/blob/main/TOOLS.md#apple-mail-tachikoma-vm), adapted for direct macOS use (not VM-based).
 
+The archive-search path comes from
+[issue #69](https://github.com/eins78/agent-skills/issues/69): Spotlight returned 0
+on a large multi-account store and AppleScript cross-account search was unusable at
+that scale. The reported recipes were re-verified before being documented, and
+corrected where measurement disagreed — see Testing.
+
 ## Dependencies
 
-- macOS with Mail.app
-- Automation permissions for the calling terminal app
+- macOS with Mail.app (AppleScript path)
+- Automation permissions for the calling terminal app (AppleScript path)
+- **Full Disk Access** for the calling terminal app (archive-search path)
+- `ripgrep` and Python 3 (archive-search path; Python 3 is stdlib-only)
 
 ## Limitations
 
 - **Read only** — cannot send, delete, or modify emails
-- **Requires Mail.app** — must be running and logged in
+- **Requires Mail.app** — must be running and logged in (AppleScript path only)
 - **Permission dialogs** — first access may trigger macOS permission prompt
-- **Performance** — searching large mailboxes can be slow
+- **Spotlight is unavailable** — `~/Library/Mail` is not indexed; `mdfind` silently
+  returns 0 for every query
+- **Full Disk Access failures are silent** — without it, `rg` returns 0 results
+  rather than an error, especially with `--no-messages`
+- **Attachment text is unsearchable locally** — base64 in full messages, absent
+  entirely from `.partial.emlx`; extract via the AppleScript `Save attachments`
+  recipe first
+- **Performance** — AppleScript search across many accounts is impractical; use the
+  archive path
 
 ## Testing
 
 ```bash
+# Parser smoke test — synthetic fixture, touches no real mail
+bash skills/apple-mail/tests/test-emlx.sh
+
 # Verify Mail.app is accessible
 osascript -e 'tell application "Mail" to get name of every account'
 
@@ -62,6 +109,9 @@ osascript -e 'tell application "Mail"
     log (name of a)
   end repeat
 end tell'
+
+# Verify archive access (0 means no Full Disk Access, not an empty archive)
+rg --files ~/Library/Mail -g '*.emlx' | wc -l
 ```
 
 The attachment commands added in 1.1.0 were verified end-to-end against a real
@@ -69,12 +119,34 @@ mailbox: listing, saving four attachments across four messages via the `my
 posixTarget(…)` handler, and byte-size comparison against the originals. The two
 gotchas were confirmed by reproducing each failure and its fix.
 
+`tests/test-emlx.sh` builds an `.emlx` fixture exercising a MIME-encoded subject, a
+folded header, quoted-printable body, and a stubbed attachment part, then asserts
+`emlx.py` decodes each. It is not run by `pnpm test`.
+
+### Validation of the issue #69 recipes
+
+Verified against a real multi-account store (7 accounts, ~116k `.emlx`, 1.8 GB) on
+the authoring machine — a different and smaller store than the reporter's:
+
+| Claim | Result |
+|-------|--------|
+| `mdfind -onlyin ~/Library/Mail` returns 0 | **Confirmed** — 0 for every term tried, while `mdutil -s /` reports indexing enabled and `kMDItemTextContent` is `(null)` |
+| `rg` over `.emlx` is fast | **Confirmed** — full-archive search in ~3s |
+| `-g '*.emlx'` covers `*.partial.emlx` | **Confirmed** — no extra glob needed |
+| Subjects come back MIME-encoded from raw grep | **Confirmed** — ~24% of messages |
+| Partials "may lack the body" | **Corrected** — text bodies are intact; only attachment parts are stubbed (empty payload + `X-Apple-Content-Length`) |
+| Shell `grep`/`cut` header triage | **Replaced** — truncates ~20% folded subjects, does not decode, and `sort -u` orders dates lexicographically |
+| Search path `~/Library/Mail/V10` | **Broadened** to `~/Library/Mail` — version dirs change across macOS releases |
+
 ## Known Gaps
 
 - **Terminology collisions are only partly enumerated.** The reserved-word list in
   SKILL.md was found by probing common identifiers, not by reading Mail's `.sdef`.
   Generating the full list from the dictionary would be more reliable.
 - **No write operations by design** — see Limitations.
+- **Attachment *contents* are not searchable.** The archive path cannot see inside
+  attachments (base64 when present, absent from `.partial.emlx`); extracting them
+  is an AppleScript-path job.
 
 ## Future Improvements
 
@@ -82,3 +154,4 @@ gotchas were confirmed by reproducing each failure and its fix.
 - Mailbox-specific search helpers
 - Unread count per account
 - Helper script for bulk attachment extraction with name sanitization
+- Optional attachment-text extraction (would need `pdftotext` and friends)

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -10,13 +10,20 @@ metadata:
 
 # Apple Mail (Read Only)
 
-Read email via Mail.app AppleScript. **No sending or modifying emails.**
+Read email two ways: **Mail.app AppleScript** for live state and attachments, and
+**`ripgrep` over the on-disk `.emlx` files** for searching large archives.
+**No sending or modifying emails.**
 
 ## Prerequisites
+
+**AppleScript path:**
 
 - Mail.app running and logged in
 - Automation permissions granted (System Settings → Privacy & Security → Automation → Terminal/Claude Code → Mail)
 - If first access attempt times out, ask user to check for macOS permission dialog
+
+**Archive-search path:** Full Disk Access for the calling terminal app (System
+Settings → Privacy & Security → Full Disk Access). Mail.app need not be running.
 
 ## Reliability: always wrap osascript with timeout + retry
 
@@ -106,6 +113,9 @@ end tell'
 
 ### Search across all mailboxes
 
+Only for small stores or a handful of accounts. For old mail, or once the account
+count climbs, this becomes unusable — use **Searching large archives** below instead.
+
 ```bash
 osascript -e 'tell application "Mail"
   set foundMsgs to (messages of every mailbox of every account whose subject contains "keyword")
@@ -159,6 +169,8 @@ Attachment names often contain `:` (e.g. `SOA-2026-08-02-12:20:06.xlsx`). It sav
 
 Fallback: `source of msg` returns the raw MIME, so Python's `email` module can extract parts without AppleScript at all. Useful when a mailbox is wedged or names need heavy cleanup.
 
+That fallback still goes through Mail. To skip it entirely, the same message is already on disk as an `.emlx` file — see **Searching large archives** below, which parses it with the same `email` module and no `tell` block at all.
+
 ## Gotchas inside `tell application "Mail"`
 
 Both of these have one root cause: **unqualified terms resolve against Mail's dictionary, not AppleScript's.**
@@ -170,6 +182,128 @@ Both of these have one root cause: **unqualified terms resolve against Mail's di
 `base` · `name` · `subject` · `content` · `file` · `path` · `index` · `size` · `date` · `text` · `character`
 
 Prefix them — `basePath`, `msgSubject`, `outFile`. The failure is a *syntax* error at compile time for some (`base`, `file`, `date`, `text`, `character`) and a *runtime* error for others (`name`, `subject`, `content`, `index`, `size`), so a script can parse cleanly and still blow up mid-loop.
+
+## Searching large archives
+
+**Use this path to find old mail, or when the account count is high.** Cross-account
+AppleScript search degrades badly as accounts accumulate, and the bridge hangs
+intermittently besides (see *Reliability: always wrap osascript with timeout +
+retry*).
+
+The two paths are complements, not rivals — AppleScript still owns live state
+(unread counts, recent inbox, account and mailbox names) and attachment
+extraction, which the on-disk path cannot do. Use this one to *locate* a message
+across a large archive; use AppleScript to act on it once found.
+
+Mail stores each message as an `.emlx` file under `~/Library/Mail/`, so `ripgrep`
+searches the whole archive directly. This is read-only: it never opens Mail.app.
+
+### 1. Confirm the store is readable — do this first
+
+Both of the failure modes below return **zero results, not an error**. Establish
+that you can actually read the files before believing any empty result:
+
+```bash
+rg --files ~/Library/Mail -g '*.emlx' | wc -l
+```
+
+A count of 0, or a permission error, means the search is blind — not that the
+archive is empty. Reading `~/Library/Mail` requires **Full Disk Access** for the
+calling terminal app (System Settings → Privacy & Security → Full Disk Access).
+
+### 2. Search
+
+```bash
+rg -il --no-messages 'search\.term' ~/Library/Mail -g '*.emlx' > /tmp/matches.txt
+wc -l < /tmp/matches.txt
+```
+
+- Search `~/Library/Mail`, not `~/Library/Mail/V10` — the version directory changes
+  across macOS releases and more than one can coexist.
+- `-g '*.emlx'` **already includes `*.partial.emlx`**; no second glob is needed.
+- Use `-F` for a literal term. Email addresses and domains contain regex
+  metacharacters (`.`, `+`), so `rg -ilF 'name+tag@example.com'` avoids surprises.
+- Drop `--no-messages` on the first run. It suppresses genuine read errors, which
+  is exactly how a permissions problem disguises itself as "no such mail."
+
+### 3. Triage the hits
+
+Do not pull headers out with `grep`. Roughly a quarter of `Subject:` headers are
+MIME-encoded (`=?UTF-8?B?...?=`) and a fifth are folded across continuation lines,
+so a line-oriented `grep`/`cut` pipeline returns mojibake and truncated subjects.
+The bundled parser decodes both:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/emlx.py" list < /tmp/matches.txt
+```
+
+Prints one TSV row per message — `UTC date, from, subject, flags, path` — sorted
+oldest first. The date column is UTC precisely so it stays sortable with `sort`.
+
+### 4. Read one message
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/emlx.py" show /path/to/123.emlx
+```
+
+Decoded headers plus the body, preferring `text/plain` and falling back to
+`text/html` — a tenth of messages have no plain-text part at all, so a
+plain-text-only extraction silently prints nothing for them.
+
+### `.emlx` format
+
+A byte-count line, then the RFC822 message, then an XML plist trailer. The count
+is why the message must be sliced out before parsing rather than fed to an
+RFC822 parser whole.
+
+### `*.partial.emlx` — include them
+
+Mail writes `.partial.emlx` when it has not downloaded the entire message. They
+can be a large share of the archive, and **they are worth searching**: headers and
+text body are normally present and intact.
+
+What they lack is attachment payloads. Such a part keeps its headers and carries
+`X-Apple-Content-Length`, but its body is empty — measured here as attachments only
+(`application/pdf`, `image/png`, `image/jpeg`, `application/pgp-signature`). So a
+term that exists only inside an attachment will not match locally. `emlx.py` flags
+these as `NOT-DOWNLOADED:<type>`; open the message in Mail.app to fetch the rest.
+
+Note this bounds what a local grep can find in general: attachment text is
+base64-encoded even in fully-downloaded messages, so it never matches a plaintext
+search regardless. Searching *inside* attachments is a separate job — extract them
+first with **Save attachments** above, then search the extracted files.
+
+### Spotlight does not work here
+
+```bash
+mdfind -onlyin ~/Library/Mail 'some term you know exists'   # → 0
+```
+
+`~/Library/Mail` is not Spotlight-indexed on current macOS. **`mdfind` returns 0
+for every query, and 0 reads as "no such mail" when it actually means "no index."**
+Do not use `mdfind` to conclude a message does not exist, and do not treat its
+silence as evidence.
+
+Volume-level indexing being enabled is not evidence the mail store is indexed —
+these two commands distinguish the cases in seconds:
+
+```bash
+mdutil -s /                                          # "Indexing enabled." — volume is fine
+mdls -name kMDItemTextContent /path/to/some.emlx     # (null) — yet no text was indexed
+```
+
+## Common Mistakes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `mdfind -onlyin ~/Library/Mail` returns 0 | The Mail store is not Spotlight-indexed — never a negative result | Search the `.emlx` files with `rg`; confirm with `mdls -name kMDItemTextContent` |
+| `rg` over `~/Library/Mail` returns 0 | No Full Disk Access, and `--no-messages` hid the errors | Run `rg --files ~/Library/Mail -g '*.emlx' \| wc -l` first; grant Full Disk Access |
+| Subjects appear as `=?UTF-8?B?...?=` | Raw `grep` does not decode MIME-encoded headers | Use `emlx.py list` |
+| Subject is cut off mid-sentence | Header folded onto a continuation line; `grep -m1` took only the first | Use `emlx.py list` |
+| Message found, but body prints empty | Message has no `text/plain` part | Use `emlx.py show`, which falls back to `text/html` |
+| Term is known to be in the mail but does not match | It lives in an attachment — absent in `.partial.emlx`, base64 elsewhere | Extract via **Save attachments**, then search those files; check for the `NOT-DOWNLOADED` flag |
+| Cross-account AppleScript search hangs | Impractical across many accounts | Use **Searching large archives** |
+| `-1728 Can't get POSIX file "…"`, or `Can't set «constant ldaslsba» to …` | Unqualified terms resolve against Mail's dictionary | See **Gotchas inside `tell application "Mail"`** |
 
 ## Notes
 

--- a/skills/apple-mail/scripts/emlx.py
+++ b/skills/apple-mail/scripts/emlx.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Read Apple Mail .emlx files: decoded headers for triage, or one full message.
+
+An .emlx file is a byte-count line, then the RFC822 message, then an XML plist
+trailer. Parsing it with the stdlib email package (policy=default) decodes
+MIME-encoded headers (=?UTF-8?B?...?=) and transfer-encoded bodies, which raw
+grep cannot do.
+
+Usage:
+  emlx.py list [FILE...]     # TSV: date, from, subject, flags, path (stdin if no FILE)
+  emlx.py show FILE          # decoded headers + best-available body
+
+Read only: never writes to or modifies the Mail store.
+"""
+
+import email
+import email.policy
+import sys
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+
+# Mail stubs out MIME parts it has not downloaded: the part keeps its headers
+# and carries this one, but its payload is empty. Only attachments, in practice.
+STUB_HEADER = "X-Apple-Content-Length"
+
+
+def parse(path):
+    """Return the parsed message from an .emlx file, or None if unreadable."""
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return None
+    try:
+        nl = raw.index(b"\n")
+        length = int(raw[:nl].strip())
+    except ValueError:
+        # Not an .emlx length prefix — try the whole file as RFC822.
+        nl, length = -1, len(raw)
+    try:
+        return email.message_from_bytes(
+            raw[nl + 1 : nl + 1 + length], policy=email.policy.default
+        )
+    except Exception as exc:  # noqa: BLE001 — one bad message must not stop a sweep
+        print(f"{path}: parse failed: {exc}", file=sys.stderr)
+        return None
+
+
+def header(msg, name):
+    """Decoded header as a single line, or '' — never raises on malformed input."""
+    try:
+        value = msg[name]
+    except Exception:  # noqa: BLE001 — malformed headers raise on access
+        return ""
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def sort_key(msg):
+    """UTC datetime for chronological sort; None-tolerant.
+
+    Normalising to UTC keeps the printed column lexicographically sortable —
+    local offsets vary across a long archive, so ISO strings carrying them
+    compare wrongly under `sort`.
+    """
+    try:
+        dt = parsedate_to_datetime(msg["Date"])
+    except Exception:  # noqa: BLE001 — absent or malformed Date
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt.astimezone(timezone.utc)
+
+
+def stubbed_parts(msg):
+    """Content types Mail has not downloaded (declared length, empty payload)."""
+    out = []
+    for part in msg.walk():
+        if part.get_content_maintype() == "multipart":
+            continue
+        if part.get(STUB_HEADER) is not None and not part.get_payload(decode=True):
+            out.append(part.get_content_type())
+    return out
+
+
+def best_body(msg):
+    """Body text, preferring text/plain and falling back to text/html."""
+    try:
+        part = msg.get_body(preferencelist=("plain", "html"))
+    except Exception:  # noqa: BLE001
+        part = None
+    if part is None:
+        return "", None
+    try:
+        return part.get_content(), part.get_content_type()
+    except Exception as exc:  # noqa: BLE001 — unknown/invalid charset
+        return f"[body could not be decoded: {exc}]", part.get_content_type()
+
+
+def cmd_list(paths):
+    rows = []
+    for path in paths:
+        msg = parse(path)
+        if msg is None:
+            continue
+        flags = []
+        if path.endswith(".partial.emlx"):
+            flags.append("PARTIAL")
+        stubs = stubbed_parts(msg)
+        if stubs:
+            flags.append("NOT-DOWNLOADED:" + ",".join(sorted(set(stubs))))
+        key = sort_key(msg)
+        date = (key.strftime("%Y-%m-%dT%H:%M:%SZ") if key
+                else (header(msg, "Date") or "?"))
+        rows.append((key, date, header(msg, "From"), header(msg, "Subject"),
+                     ",".join(flags), path))
+    # Undated messages sort last rather than crashing the comparison.
+    rows.sort(key=lambda r: (r[0] is None, r[0]))
+    for _, date, sender, subject, flags, path in rows:
+        print(f"{date}\t{sender}\t{subject}\t{flags}\t{path}")
+
+
+def cmd_show(path):
+    msg = parse(path)
+    if msg is None:
+        return 1
+    for name in ("Date", "From", "To", "Cc", "Subject", "Message-ID"):
+        value = header(msg, name)
+        if value:
+            print(f"{name}: {value}")
+    stubs = stubbed_parts(msg)
+    if stubs:
+        print(f"\n[not downloaded: {', '.join(sorted(set(stubs)))} "
+              f"— open the message in Mail.app to fetch it]")
+    body, kind = best_body(msg)
+    print(f"\n--- body ({kind or 'none found'}) ---\n{body}")
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2 or argv[1] not in ("list", "show"):
+        print(__doc__, file=sys.stderr)
+        return 2
+    if argv[1] == "show":
+        if len(argv) != 3:
+            print("usage: emlx.py show FILE", file=sys.stderr)
+            return 2
+        return cmd_show(argv[2])
+    paths = argv[2:] or [line.strip() for line in sys.stdin if line.strip()]
+    cmd_list(paths)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/apple-mail/tests/test-emlx.sh
+++ b/skills/apple-mail/tests/test-emlx.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/emlx.py using a synthetic .emlx fixture.
+# Touches no real mail. Run: bash skills/apple-mail/tests/test-emlx.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+emlx="$here/../scripts/emlx.py"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+check() { # check <label> <expected-substring> <actual>
+  if [[ "$3" == *"$2"* ]]; then
+    echo "  ok   — $1"
+  else
+    echo "  FAIL — $1: expected to find '$2'"
+    fail=1
+  fi
+}
+
+# Build an .emlx: byte-count line, RFC822 message, XML plist trailer.
+# Exercises the three traps raw grep hits — a MIME-encoded subject, a subject
+# folded across lines, and an attachment part Mail has not downloaded.
+build_fixture() {
+  local msg="$tmp/msg.raw"
+  {
+    printf 'Date: Tue, 4 Mar 2025 09:15:00 +0100\r\n'
+    printf 'From: Sender <sender@example.com>\r\n'
+    printf 'To: recipient@example.com\r\n'
+    # =?UTF-8?B?w4RwZmVs?= is base64 for "Äpfel"; second line is a fold.
+    printf 'Subject: =?UTF-8?B?w4RwZmVs?= order\r\n\tconfirmation 12345\r\n'
+    printf 'Message-ID: <test@example.com>\r\n'
+    printf 'MIME-Version: 1.0\r\n'
+    printf 'Content-Type: multipart/mixed; boundary="BOUND"\r\n'
+    printf '\r\n'
+    printf -- '--BOUND\r\n'
+    printf 'Content-Type: text/plain; charset=utf-8\r\n'
+    printf 'Content-Transfer-Encoding: quoted-printable\r\n'
+    printf '\r\n'
+    printf 'tracking code WIDGET-42 for =C3=84pfel\r\n'
+    printf -- '--BOUND\r\n'
+    printf 'Content-Type: application/pdf; name="invoice.pdf"\r\n'
+    printf 'X-Apple-Content-Length: 90210\r\n'
+    printf '\r\n'
+    printf -- '--BOUND--\r\n'
+  } > "$msg"
+
+  local n
+  n=$(wc -c < "$msg" | tr -d ' ')
+  {
+    printf '%s\n' "$n"
+    cat "$msg"
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict></dict></plist>\n'
+  } > "$tmp/1.partial.emlx"
+}
+
+build_fixture
+
+echo "list mode:"
+listed="$(python3 "$emlx" list "$tmp/1.partial.emlx")"
+check "decodes MIME-encoded subject"      "Äpfel order"   "$listed"
+check "unfolds continuation line"         "confirmation 12345" "$listed"
+check "subject is not left encoded"       "order"         "$listed"
+check "emits UTC timestamp"               "2025-03-04T08:15:00Z" "$listed"
+check "flags the partial file"            "PARTIAL"       "$listed"
+check "flags undownloaded attachment"     "NOT-DOWNLOADED:application/pdf" "$listed"
+if [[ "$listed" == *"=?"* ]]; then
+  echo "  FAIL — subject still contains MIME encoding"
+  fail=1
+else
+  echo "  ok   — no residual '=?' encoding"
+fi
+
+echo "show mode:"
+shown="$(python3 "$emlx" show "$tmp/1.partial.emlx")"
+check "decodes quoted-printable body"     "tracking code WIDGET-42" "$shown"
+check "decodes charset in body"           "Äpfel"         "$shown"
+check "reports the undownloaded part"     "not downloaded: application/pdf" "$shown"
+
+echo "robustness:"
+printf 'not an emlx\n' > "$tmp/junk.emlx"
+: > "$tmp/empty.emlx"
+if python3 "$emlx" list "$tmp/junk.emlx" "$tmp/empty.emlx" >/dev/null 2>&1; then
+  echo "  ok   — malformed and empty files do not crash the sweep"
+else
+  echo "  FAIL — malformed input crashed"
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS"
+else
+  echo "FAILED"
+  exit 1
+fi


### PR DESCRIPTION
Closes #69

> **Rebased onto `main` (was CONFLICTING).** #70 `apple-mail-attachments` touched the same two files at the same insertion point. Both sides are kept in full — see *Integration with #70* below. `pnpm test` and `pnpm run validate` both pass in CI.

## Integration with #70

The conflict was structural, not semantic: #70 and this branch both appended sections immediately before `## Notes`, and git could not choose an order. Nothing in #70 was overwritten — I verified every line it added to `SKILL.md` and `README.md` is still present **verbatim** in the rebased file, and its changeset is untouched.

The merged `SKILL.md` is ordered so the document argues in one direction: AppleScript commands (including #70's attachment recipes) → #70's `tell`-block gotchas → archive search → a Common Mistakes table spanning both → Notes.

Beyond ordering, four edits make it read as one document rather than two stitched halves:

- **#70's Python fallback now connects to this work.** It noted that `source of msg` returns raw MIME for Python's `email` module to parse. That is the same module this branch uses — so it now points onward to the on-disk path, which skips the `tell` block entirely.
- **This section points back for attachments.** My original text said a term hiding in an attachment means "open it in Mail.app". #70 added a real extraction recipe, so it now names **Save attachments** instead, in both the prose and the Common Mistakes table.
- **Corrected an under-claim in my own framing.** I had written "reserve AppleScript for live and recent-inbox queries." After #70 that is wrong — attachment extraction is AppleScript-only and is not a "live query". The section now frames the paths as complementary: the archive path *locates* a message, AppleScript *acts* on it.
- **The skill's opening line named only one path.** It read "Read email via Mail.app AppleScript", which stopped being accurate once a non-AppleScript path existed. It now names both, and Prerequisites are split per path — Automation permission for AppleScript, Full Disk Access for the archive path.

`README.md` was integrated the same way: both testing commands, both verification write-ups, both Future Improvements bullets, and #70's Known Gaps section retained with one gap added (attachment *contents* are not searchable from the archive path).

## Changeset: kept, deliberately

#73 dropped its changeset because `send-to-kindle` was sitting at an unreleased `0.1.0` with a pending changeset already covering it — the fix shipped as part of that same unreleased version. I checked whether `apple-mail` is in that position. It is not:

- `apple-mail` **is** released — tag `apple-mail@1.0.0`, and `marketplace.json` on `main` carries `1.0.0`.
- Unlike #73, this is independent new functionality, not a correction to content that has not shipped yet.
- Dropping it would leave the `1.1.0` CHANGELOG describing only attachments, silently omitting archive search.

There is no double-bump risk: two pending `apple-mail: minor` changesets (#70's and this one) collapse to a single `1.0.0 → 1.1.0`, which I confirmed by dry-running `bump-skill-versions.sh` and reverting. `metadata.version` stays at `1.0.0` in the diff, per CLAUDE.md.

---


## What

Adds a **Searching large archives** section to `apple-mail`: a ripgrep recipe over the `.emlx` files, the file format, and a bundled `scripts/emlx.py` for triage and reading. AppleScript stays the documented path for live and recent-inbox queries, cross-referencing the existing bridge-hang warning rather than repeating it.

The unifying theme is **failures that return 0 instead of an error**. `mdfind` returns 0 because the store isn't indexed; that reads as "no such mail" but means "no index". Per CLAUDE.md's gates-over-rules principle, the readability precheck is step 1 of the recipe rather than a prose caveat.

## Verification — I ran everything, and corrected what didn't hold

The issue's snippets are a bug report, not tested skill content. Measured against a real multi-account store on this machine, which is **smaller than the reporter's**: **7 accounts, 116,384 `.emlx`, 1.8 GB** (reporter: 18 / 162,320 / 5.1 GB). Numbers below are mine, not theirs.

| Claim | Result |
|---|---|
| `mdfind -onlyin ~/Library/Mail` returns 0 | **Confirmed.** 0 for every term tried, while `mdutil -s /` reports indexing enabled and `kMDItemTextContent` is `(null)` — that pair is now the documented diagnostic |
| ripgrep over `.emlx` is fast | **Confirmed.** Full archive in ~3.4s; a 17,367-hit triage ran with 0 errors |
| `-g '*.emlx'` covers `*.partial.emlx` | **Confirmed** — 65,663 matched. Non-obvious, so stated explicitly |
| Raw grep returns MIME-encoded subjects | **Confirmed.** ~24% of messages — 27,725 files |

### Corrections

- **Partials are not missing their bodies.** The issue says `*.partial.emlx` "may lack the body you're looking for". Measured: their text bodies are intact, with a *longer* median than full messages. The real mechanism is per-part — an undownloaded part keeps its headers and carries `X-Apple-Content-Length` with an empty payload, and only for attachments: `image/png`, `image/jpeg`, `application/pdf`, `application/pgp-signature`. 647 stub parts across 1,500 partials; full messages had **zero**. Documented as measured, and surfaced as a `NOT-DOWNLOADED:<type>` flag.
- **The shell `grep`/`cut` triage loop is replaced.** It truncates folded subjects — **20%** of messages have a folded `Subject:` — doesn't decode MIME — **24%** — and its `sort -u` orders dates lexicographically. Together that's wrong for roughly a third of messages, and it is exactly what produced the `=?UTF-8?B?...?=` output the issue reported. `email.policy.default` handles all three.
- **`~/Library/Mail/V10` broadened to `~/Library/Mail`.** Version dirs change across macOS releases. I did observe a coexisting `V2/` here, but it was **empty** — this is reasoning about version drift, not a tested recovery of legacy mail.
- **The fix had the same bug as the thing it fixes.** Without Full Disk Access, `rg --no-messages` returns a silent 0, verified by making a directory unreadable. Hence the precheck, and the advice to drop `--no-messages` on the first run.
- **`text/plain`-only body extraction silently prints nothing** for the **9.5%** of messages with no plain-text part. Now uses `get_body` with a `plain`, `html` preference list.
- Added `-F` guidance — email addresses and domains contain regex metacharacters.

### Things I checked that turned out fine

- ripgrep's binary heuristic is a non-issue: **0 of 3,000** `.emlx` files contain a NUL byte, since attachments are base64. No `-a` needed.
- `rg --files` and `find` agree exactly at 116,384, so no `--hidden --no-ignore` needed.
- The length-prefix parse succeeded on **4,000/4,000** sampled messages, partials included.

## Testing

`tests/test-emlx.sh` — 11 assertions over a **synthetic** fixture: MIME-encoded subject, folded header, quoted-printable body, stubbed attachment part. Touches no real mail. Passes; `shellcheck` clean. Not wired into `pnpm test`, per the repo convention for post-install smoke tests.

## Notes

- **Version not hand-edited.** Per CLAUDE.md, `metadata.version` stays at `1.0.0`; the changeset carries `apple-mail: minor` in its `bumps:` block. I dry-ran `bump-skill-versions.sh` to confirm it resolves — `1.0.0` to `1.1.0` — and reverted.
- **`pnpm test` now verified in CI.** I still cannot run it locally — this worktree has no `node_modules`, and `pnpm install` would fire the `postinstall` that writes this branch's unmerged skills into `~/.claude/skills`. CI runs it in a disposable container, where that side effect is harmless: both `pnpm test` and `pnpm run validate` pass.
- **No personal data.** All examples use `example.com`; no real addresses, account UUIDs, subjects, or message content in the skill, tests, or this description. Root README's skills table needs no change — no skill added or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

