### PR TITLE
send-to-kindle: verify delivery after sending

### DIFF
--- a/.changeset/20260808-091238.md
+++ b/.changeset/20260808-091238.md
@@ -1,0 +1,19 @@
+---
+"@eins78/agent-skills": minor
+---
+
+**`send-to-kindle`** — a send that leaves the mail client is not a delivery. Adds the post-send verification step.
+
+- New **Verify delivery** section. A send has three fates and two of them look identical at the moment of sending: dropped at the gate (unapproved sender, never bounces), accepted-then-failed (an **asynchronous** bounce from Amazon Kindle Support naming the file and an error code), and delivered (no mail at all). Success is signalled by silence, so the check has to be time-boxed: look for the bounce at ~2 min, again at ~15 min.
+- States plainly that **absence of a bounce is weak evidence, not confirmation** — it cannot separate "delivered" from "silently dropped", because neither produces mail. Only a positive bounce, or the document appearing on the device, is conclusive.
+- Seeds a **bounce error-code table** with `E999 - Send to Kindle Internal Error`: Amazon-side, says nothing about the file, and the correct response is to resend. Observed on a well-formed 47 KB EPUB from the standard pipeline; a rebuilt copy of the same document went through cleanly.
+- Records bounce latency as **n=1 (~14 s)** and marks the code table as seeded rather than surveyed, so neither reads as a measured distribution.
+- Two new Common Mistakes rows: a bounce **exonerates** the approved-sender list (a rejected sender produces no bounce at all), and reporting "delivered" off a successful send is itself the mistake.
+
+Procedural only — no sender, no addresses, no configuration contract, per the skill's standing scope.
+
+<!--
+bumps:
+  skills:
+    send-to-kindle: minor
+-->

--- a/skills/send-to-kindle/README.md
+++ b/skills/send-to-kindle/README.md
@@ -9,6 +9,11 @@ unapproved sender, and per-device addressing selected by a misleading display
 name). It also records the one hard limit — highlights on personal documents
 never reach the cloud.
 
+A third fate sits between those two: Amazon accepts the mail and then fails
+while processing it, reporting that **asynchronously** by bounce, minutes after
+the send returned success. *Verify delivery* covers the time-boxed check that
+separates the three, and why silence is only weak evidence of success.
+
 The skill stops short of sending. It documents the manual email step in three
 facts and ships no sender code.
 
@@ -65,7 +70,7 @@ carry the discovery load.
 
 ```
 send-to-kindle/
-├── SKILL.md       # Format choice, routes, the three send facts, size limits, highlights
+├── SKILL.md       # Format choice, routes, the three send facts, delivery verification, size limits, highlights
 └── README.md      # This file
 ```
 
@@ -97,6 +102,13 @@ not automated.
 6. **Highlights test:** "sync my Kindle highlights from that document to
    Readwise" → agent should identify this as structurally impossible for
    personal documents, not attempt a workaround
+7. **Verification test:** "I sent it, the mail went out fine" → agent should
+   *not* report success on that basis, and should describe the timed bounce
+   check instead
+8. **Bounce-reading test:** "I got a mail saying there was a problem with the
+   document I sent" → agent should conclude the approved-sender list is fine
+   (a rejected sender never bounces) and route by error code, resending on
+   `E999` rather than rebuilding the file
 
 The delivery pipeline itself was verified end-to-end on 2026-08-06 (see
 Provenance) — samples were mailed to a real device and rendered correctly.
@@ -121,6 +133,11 @@ Within it, the load-bearing sources were:
 - Size ceilings: a single community guide (see Known Gaps)
 - Per-device addressing and the silent-drop behaviour: confirmed in practice
   on 2026-08-06 when the samples were sent
+- The asynchronous-bounce fate and the `E999` code: observed in practice on
+  2026-08-08, when a 47 KB EPUB built by the standard pipeline was accepted and
+  then failed Amazon-side. A rebuilt copy of the same document, sent from the
+  same approved address, went out cleanly with no bounce — which is what makes
+  `E999` a transient-and-resend case rather than a file defect
 
 **Evidence-quality caveat carried over from the dossier:** Amazon's own
 `amazon.com/gp/help/...` pages returned HTTP 503 to every automated fetch
@@ -142,6 +159,15 @@ snippets and independent trackers, not read directly from the vendor.
 - **Whether the device's format conversion preserves HTML `<input>` elements
   is untested.** The `pandoc` wrapper sidesteps it by emitting literal `[ ]`
   text; nobody has confirmed what happens if you don't.
+- **Bounce latency is n=1 and the error-code table is seeded, not surveyed.**
+  One observed `E999` arrived ~14 seconds after the send. The `~2 min / ~15 min`
+  check in SKILL.md is deliberately slower than that single measurement,
+  because latency across other error classes is unmeasured. Codes should be
+  added as observed rather than guessed.
+- **A clean send remains unconfirmable from the sending side.** No bounce is
+  consistent with both "delivered" and "silently dropped for an unapproved
+  sender". Only the document appearing on the device closes that gap, and
+  nothing in this skill can observe the device.
 - **Amazon-specific.** Kobo, reMarkable, and Pocketbook all have their own
   ingestion stories and none of them are covered here.
 - No coverage of the Kindle's own document management (collections, deleting

--- a/skills/send-to-kindle/SKILL.md
+++ b/skills/send-to-kindle/SKILL.md
@@ -68,6 +68,43 @@ purchased books, and retired Word's Send-to-Kindle button. Statuses here are
 The allowlist is separate from the ingress address; both live under
 *Manage Your Content and Devices → Preferences → Personal Document Settings*.
 
+## Verify delivery — sending is not the finish line
+
+A send that leaves your mail client has three possible fates, and **two of them
+look identical at the moment of sending**. Do not report a delivery as
+successful on the strength of the send alone.
+
+| Fate | What you observe | What it means |
+|---|---|---|
+| Dropped at the gate | Nothing, ever. No bounce | Sender not on the approved list — see fact 3 above |
+| Accepted, then failed | An **asynchronous bounce** from `Amazon Kindle Support <do-not-reply@amazon.com>`, subject *"There was a problem with the document(s) you sent to Kindle"*, naming the file and an error code | Amazon took the mail and failed while processing it. The allowlist is *fine* |
+| Delivered | No mail of any kind | Success is signalled by silence, which is why the check has to be time-boxed |
+
+**The check.** After sending, watch the *sending* account's inbox for that
+bounce subject:
+
+1. **At ~2 minutes** — an observed bounce is conclusive failure; act on it.
+2. **At ~15 minutes** — if still nothing, treat the send as probably delivered.
+
+Absence of a bounce is **weak evidence of success, not confirmation.** It
+cannot distinguish "delivered" from "silently dropped for an unapproved
+sender", because that case never bounces either. Only a positive bounce, or the
+document appearing on the device, is conclusive.
+
+Timing is worth calibrating rather than trusting: one observed `E999` bounce
+arrived **~14 seconds** after the send (n=1). The two-step check above is
+deliberately slower than that single data point, because bounce latency across
+error classes is unmeasured.
+
+### Bounce error codes
+
+| Code | Meaning | Response |
+|---|---|---|
+| `E999 - Send to Kindle Internal Error` | Amazon-side internal failure. Not a statement about your file | **Transient — resend.** Observed once on a well-formed 47 KB EPUB that had been built by the standard pipeline; a rebuilt copy of the same document went through cleanly |
+
+Treat this table as seeded, not complete — add codes as they are observed
+rather than guessing at their meaning.
+
 ## Size ceilings
 
 | Route | Ceiling |
@@ -99,6 +136,8 @@ Plan around a manual step, or do not promise highlight round-tripping.
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | Sent it, nothing arrived, no bounce | Sender not on the approved list | Add the exact sending address under Personal Document Settings |
+| Sent it, got a bounce naming the file | Amazon accepted the mail, then failed processing it | The allowlist is **not** the problem — a rejected sender never bounces. Read the error code; `E999` is transient, so resend |
+| Reported "delivered" because the send succeeded | No post-send check was made | See *Verify delivery* — watch the sending inbox for a bounce at ~2 min and ~15 min |
 | Arrived on the wrong person's Kindle | Targeted by device display name | Target by ingress address or serial; names are user-set and often stale |
 | Reader has to pan and zoom every page | A PDF was sent | Send EPUB and let Send-to-Kindle convert it |
 | Copied an `.epub` over USB, it never appears in the library | Raw EPUB isn't indexed on-device | Convert to AZW3 locally, or use email delivery instead |


### PR DESCRIPTION
## Why

First real failure of the Kindle pipeline (2026-08-08) was invisible to every check the skill described. The mail left cleanly, the outbox drained, the message landed in Sent — and Amazon bounced it **~14 seconds later** with `E999 - Send to Kindle Internal Error`. The bounce is asynchronous, so the send call had already returned success.

The skill already documented the silent-drop trap, and that trained the wrong reflex: it framed *"no bounce"* as the failure signature, leaving a bounce nowhere to land. In fact a bounce is **good news about the allowlist** — a rejected sender produces no mail at all. The two are complementary, not variants of each other.

## What changed

- **New `Verify delivery` section** in SKILL.md. Three fates, two of which look identical at send time; a time-boxed check at ~2 min and ~15 min.
- **Explicit that silence is weak evidence, not confirmation.** "Delivered" and "silently dropped" are indistinguishable from the sending side — only the document appearing on the device closes that gap.
- **Seeded bounce error-code table.** `E999` is Amazon-side and transient: resend rather than rebuild. A rebuilt copy of the same 47 KB EPUB, same approved sender, went through with no bounce.
- **Two Common Mistakes rows** — a bounce exonerates the allowlist; reporting "delivered" off a successful send is itself the mistake.
- README: purpose, file structure, two new trigger tests, provenance, and Known Gaps.

## Evidence quality

Bounce latency is marked **n=1** and the code table **seeded, not surveyed**, so neither reads as a measured distribution. The `~2 min / ~15 min` check is deliberately slower than the single 14 s measurement, because latency across other error classes is unmeasured.

## Scope

Procedural only — still no sender, no addresses, no configuration contract, per the skill's standing scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
